### PR TITLE
fix: rerender function now accepts BaseLog derived instances

### DIFF
--- a/src/filters/filters.ts
+++ b/src/filters/filters.ts
@@ -1,5 +1,5 @@
 import { LogRender, Collection, LogData, LevelFilter } from '../_contracts';
-import { Log } from '../log';
+import { BaseLog } from '../log';
 import { formatLevels, isString } from '../util';
 
 /**
@@ -64,7 +64,7 @@ export function filterCollection(
  * If the provided log has been previously rendered, this function
  * re-renders it to the console.
  */
-export function rerender(log: Log): void {
+export function rerender(log: BaseLog): void {
   if (log.render) {
     render(log.render);
   }


### PR DESCRIPTION
fixes parameter type for rerender() to be BaseLog rather than Log to allow for sealed logs

fix #49