### PR TITLE
docs: updates the docs to add info about version requirements and ts config requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: npx semantic-release
   docs:
     runs-on: ubuntu-latest
-    needs: [lint, test, release]
+    needs: [lint, test]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/docs-only.yml
+++ b/.github/workflows/docs-only.yml
@@ -1,0 +1,25 @@
+name: Build
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: startsWith(github.event.head_commit.message, 'docs:')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+      - name: Build Content
+        run: yarn docs:build
+      - name: Publish
+        uses: tsunematsu21/actions-publish-gh-pages@v1.0.1
+        with:
+          dir: docs/.vuepress/dist
+          branch: gh-pages
+          token: ${{ secrets.PAGES_TOKEN }}

--- a/.github/workflows/docs-only.yml
+++ b/.github/workflows/docs-only.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Docs Only
 on:
   push:
     branches: [master]

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -12,16 +12,47 @@ npm install --save adze
 yarn add adze
 ```
 
+## Version Requirements
+
+| Dependency | Supported Versions | Notes                                    |
+| ---------- | ------------------ | ---------------------------------------- |
+| node       | >= 10.x            | When running Adze in a Node environment. |
+| typescript | >= 4.1             | When using Adze with TypeScript          |
+
+## TypeScript Configuration
+
+Adze is built to be used with TypeScript and we highly encourage using it in this way.
+
+When building your project with TypeScript, you need to make sure you use the `"DOM"` lib because Adze supports both the web browser and Node.
+
+For more information about configuring TypeScript, go to [https://www.typescriptlang.org/docs/handbook/tsconfig-json.html](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+
+### Example
+
+```json
+{
+  "compilerOptions": {
+    // ...your other options
+    "lib": ["DOM"]
+  }
+}
+```
+
 ## Importing Adze
 
 Adze comes bundled with a few different ways of accessing it. Here are some examples:
 
-### Browser
+### CDN
+
+You can import the library directly into your HTML from the [jsDelivr](https://www.jsdelivr.com/package/npm/adze) CDN.
+
+_**NOTE:** In the script tag in the example below, replace `<version>` with the version of Adze you would like to use._
 
 ```html
 <!-- In the head of your html -->
 <head>
-  <script src="path/to/adze.js"></script>
+  <!-- To use v0.5.3 you would write https://cdn.jsdelivr.net/npm/adze@0.5.3/dist/adze.min.js -->
+  <script src="https://cdn.jsdelivr.net/npm/adze@<version>/dist/adze.min.js"></script>
 </head>
 
 <!-- Using adze elsewhere in JS -->

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Adze - JavaScript Logging Library</title>
     <link rel="icon" type="image/png" href="docs/assets/favicon.png" />
 
-    <script src="dist/adze.min.js""></script>
+    <script src="https://cdn.jsdelivr.net/npm/adze@0.5.3/dist/adze.min.js"></script>
     <style>
       html,
       body {


### PR DESCRIPTION
Adds version requirements for Node and TypeScript as well as required TS configuration. Also
documents the option of installing via CDN. Adds a docs-only Github Actions workflow that will build
and deploy docs if the commit message merged to master begins with 'docs:'.

fix #51