### PR TITLE
Issue 71: Add Unstyled stdout Support

### DIFF
--- a/demo_funcs.js
+++ b/demo_funcs.js
@@ -22,6 +22,7 @@ export default function runDemo(lib, el) {
   asGroupCollapsed(lib);
   evaluation(lib);
   withTrace(lib);
+  unstyled(lib);
 }
 
 function screenshots({ adze, createShed }, el) {
@@ -31,7 +32,7 @@ function screenshots({ adze, createShed }, el) {
 
   // Let's create an Adze configuration
   var cfg = {
-    log_level: 1,
+    logLevel: 1,
   };
 
   // Now we'll create a new factory using seal
@@ -54,7 +55,7 @@ function screenshotDemo({ adze }) {
   log.log('Example log');
   log.debug('Example debug log');
   log.verbose('Example verbose log');
-  const log2 = adze({ use_emoji: true });
+  const log2 = adze({ useEmoji: true });
   log2.alert('Example alert log');
   log2.error('Example error log');
   log2.warn('Example warning log');
@@ -65,8 +66,8 @@ function screenshotDemo({ adze }) {
   log2.debug('Example debug log');
   log2.verbose('Example verbose log');
   adze({
-    use_emoji: true,
-    custom_levels: {
+    useEmoji: true,
+    customLevels: {
       customError: {
         level: 1,
         method: 'error',
@@ -94,7 +95,7 @@ function defaultLevels({ adze }) {
 
 function defaultLevelsWithEmoji({ adze }) {
   console.log('\n----- Default Levels w/ Emoji -----\n');
-  const log = adze({ use_emoji: true });
+  const log = adze({ useEmoji: true });
   log.alert('This is an alert!');
   log.error('This is an error!');
   log.warn('This is a warn!');
@@ -110,8 +111,8 @@ function defaultLevelsWithGlobalOverride({ adze, createShed, removeShed }) {
   console.log('\n----- Default Verbose Level w/ Global Overrides -----\n');
   createShed({
     global_cfg: {
-      use_emoji: true,
-      log_levels: {
+      useEmoji: true,
+      logLevels: {
         verbose: {
           style:
             'padding-right: 26px; background-color: CornflowerBlue; border-color: 1px solid black; color: white; border-color: #cbc9c9;',
@@ -127,7 +128,7 @@ function defaultLevelsWithGlobalOverride({ adze, createShed, removeShed }) {
 function customLevels({ adze }) {
   console.log('\n----- Custom Levels -----\n');
   const log = adze({
-    custom_levels: {
+    customLevels: {
       special: {
         level: 4,
         method: 'info',
@@ -154,8 +155,8 @@ function customLevels({ adze }) {
 function customLevelsWithEmoji({ adze }) {
   console.log('\n----- Custom Levels w/ Emoji -----\n');
   const log = adze({
-    use_emoji: true,
-    custom_levels: {
+    useEmoji: true,
+    customLevels: {
       special: {
         level: 4,
         method: 'info',
@@ -215,9 +216,9 @@ function thread({ adze, createShed, removeShed, render }) {
 function logLevelOf2({ adze }) {
   console.log('\n----- Log Level of 2 -----\n');
   const log = adze({
-    log_level: 2,
-    use_emoji: true,
-    custom_levels: {
+    logLevel: 2,
+    useEmoji: true,
+    customLevels: {
       special: {
         level: 3,
         method: 'info',
@@ -263,8 +264,8 @@ function bundleLogs({
   filterLevel,
 }) {
   console.log('\n----- Bundle Logs & Recall All -----\n');
-  const log = bundle(adze({ use_emoji: true }));
-  const divider = adze({ use_emoji: true });
+  const log = bundle(adze({ useEmoji: true }));
+  const divider = adze({ useEmoji: true });
 
   log().ns('SPACE').error('This is an error!');
   log().ns(['foo', 'SPACE']).info('A bundled log with multiple namespaces.');
@@ -292,7 +293,7 @@ function bundleLogs({
 
 function sealLogModifiers({ adze }) {
   console.log('\n----- Seals Log Modifiers for New Logs -----\n');
-  const sealed = adze({ use_emoji: true })
+  const sealed = adze({ useEmoji: true })
     .ns('sealed')
     .label('sealed-label')
     .seal();
@@ -322,7 +323,7 @@ function withTime({ adze }) {
   adze().time.log('Testing time with no store.');
   adze().timeEnd.log('Testing time with no store.');
   adze().timeNow.log('Testing timeNow with no store.');
-  adze({ use_emoji: true }).timeNow.log(
+  adze({ useEmoji: true }).timeNow.log(
     "Testing timeNow with no store and emoji's enabled."
   );
 }
@@ -366,7 +367,7 @@ function evaluation({ adze }) {
   adze()
     .assert(1 === 2)
     .log('1 does not equal 2');
-  adze({ use_emoji: true })
+  adze({ useEmoji: true })
     .assert(1 === 2)
     .log('1 does not equal 2. Testing emoji.');
   adze()
@@ -383,4 +384,9 @@ function evaluation({ adze }) {
 function withTrace({ adze }) {
   console.log('\n----- Default Log w/ Trace -----\n');
   adze().trace.log('Tracing...');
+}
+
+function unstyled({ adze }) {
+  console.log('\n----- Unstyled Log -----\n');
+  adze({ unstyled: true }).label('unstyled').log("I'm an unstyled log.");
 }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -6,7 +6,7 @@ sidebar: auto
 
 Adze is a completely configurable library by design that comes with sensible defaults. There are two primary configurations to understand; the Adze configuration and the Shed configuration. In this section we'll take a look at each configuration and explain each property in detail.
 
-_NOTE: [Chalk](https://github.com/chalk/chalk#chalklevel) is what Adze uses under the hood for terminal coloring. Because terminals differ in their color fidelity, Chalk exposes a setting allowing you to specify your fidelity. Adze is basic with its colors so the low level of 1 is sufficient, however, you can change it to your liking with the `terminal_color_fidelity` option described below. Please refer to the [Chalk](https://github.com/chalk/chalk#chalklevel) docs for information about what the fidelity levels mean._
+_NOTE: [Chalk](https://github.com/chalk/chalk#chalklevel) is what Adze uses under the hood for terminal coloring. Because terminals differ in their color fidelity, Chalk exposes a setting allowing you to specify your fidelity. Adze is basic with its colors so the low level of 1 is sufficient, however, you can change it to your liking with the `terminalColorFidelity` option described below. Please refer to the [Chalk](https://github.com/chalk/chalk#chalklevel) docs for information about what the fidelity levels mean._
 
 ## Adze Configuration
 
@@ -15,13 +15,14 @@ _NOTE: [Chalk](https://github.com/chalk/chalk#chalklevel) is what Adze uses unde
 ```typescript
 // This is the top level Adze configuration
 interface Configuration {
-  log_level?: number;
-  use_emoji?: boolean;
-  terminal_color_fidelity?: 0 | 1 | 2 | 3;
-  capture_stacktrace?: boolean;
-  base_style?: string;
-  log_levels?: LogLevels;
-  custom_levels?: Partial<LogLevels>;
+  logLevel?: number;
+  useEmoji?: boolean;
+  unstyled?: boolean;
+  terminalColorFidelity?: 0 | 1 | 2 | 3;
+  captureStacktrace?: boolean;
+  baseStyle?: string;
+  logLevels?: LogLevels;
+  customLevels?: Partial<LogLevels>;
   meta?: {
     [key: string]: unknown;
   };
@@ -46,17 +47,18 @@ type ConsoleMethod =
 
 ### Descriptions
 
-| Property Name           | Default Value                                 | Description                                                                                                                |
-| ----------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| log_level               | 8                                             | The highest log level that will be allowed to render.                                                                      |
-| use_emoji               | false                                         | Toggle emoji's on or off for log rendering.                                                                                |
-| terminal_color_fidelity | 1                                             | Control terminal color fidelity with [Chalk](https://github.com/chalk/chalk#chalklevel).                                   |
-| capture_stacktrace      | false                                         | Logs will record their stacktrace when they are created. Disabled by default for performance.                              |
-| base_style              | [Reference](#styling)                         | These styles will be applied to all default log levels.                                                                    |
-| log_levels              | [Reference](#log-levels-log-level-definition) | Configuration for default Adze log levels.                                                                                 |
-| custom_levels           | [Reference](#log-levels-log-level-definition) | Configuration for custom Adze log levels.                                                                                  |
-| meta                    | `{}`                                          | Key/value pairs of data to be applied to all logs by default.                                                              |
-| filters                 | [Reference](#filters)                         | Filters determine whether logs are allowed to print to the console/terminal based on their log level, label, or namespace. |
+| Property Name         | Default Value                                 | Description                                                                                                                |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| logLevel              | 8                                             | The highest log level that will be allowed to render.                                                                      |
+| useEmoji              | false                                         | Toggle emoji's on or off for log rendering.                                                                                |
+| unstyled              | false                                         | Disables all styling of logs. Useful for stdout use cases.                                                                 |
+| terminalColorFidelity | 1                                             | Control terminal color fidelity with [Chalk](https://github.com/chalk/chalk#chalklevel).                                   |
+| captureStacktrace     | false                                         | Logs will record their stacktrace when they are created. Disabled by default for performance.                              |
+| baseStyle             | [Reference](#styling)                         | These styles will be applied to all default log levels.                                                                    |
+| logLevels             | [Reference](#log-levels-log-level-definition) | Configuration for default Adze log levels.                                                                                 |
+| customLevels          | [Reference](#log-levels-log-level-definition) | Configuration for custom Adze log levels.                                                                                  |
+| meta                  | `{}`                                          | Key/value pairs of data to be applied to all logs by default.                                                              |
+| filters               | [Reference](#filters)                         | Filters determine whether logs are allowed to print to the console/terminal based on their log level, label, or namespace. |
 
 ## Shed Configuration
 
@@ -67,8 +69,8 @@ When you create a Shed you can provide it with configuration to control it's cac
 ```typescript
 // This is the top level Adze log configuration
 interface ShedConfig {
-  cache_limit: number;
-  global_cfg: Configuration | null;
+  cacheLimit: number;
+  globalCfg: Configuration | null;
 }
 ```
 
@@ -76,8 +78,8 @@ interface ShedConfig {
 
 | Property Name | Default Value                    | Description                                                                           |
 | ------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
-| cache_limit   | 300                              | The maximum number of logs that Shed will cache. This exists to prevent memory leaks. |
-| global_cfg    | [Reference](#adze-configuration) | Adze configuration that will override all other Adze log configurations.              |
+| cacheLimit    | 300                              | The maximum number of logs that Shed will cache. This exists to prevent memory leaks. |
+| globalCfg     | [Reference](#adze-configuration) | Adze configuration that will override all other Adze log configurations.              |
 
 ## Log Levels / Log Level Definition
 
@@ -107,15 +109,15 @@ interface LogLevelDefinition {
 import { adze } from 'adze';
 
 const config = {
-  log_level: 11,
-  use_emoji: true,
+  logLevel: 11,
+  useEmoji: true,
   // Overriding some default log level settings
-  log_levels: {
+  logLevels: {
     log: {
       emoji: '🧙‍♂️', // We'll change the default log emoji to a wizard for funsies
     },
   },
-  custom_levels: {
+  customLevels: {
     // We'll create a new log level called foobar that goes to 11
     foobar: {
       level: 11,
@@ -140,7 +142,7 @@ adze(config).custom('foobar', '#$%&%#$@&!'); // Anger!
 
 ## Styling
 
-Although Adze comes with some pretty default styles, all logs within Adze can have their styling customized. Default log level styling is a combination of the `base_style` property plus the `style` property on its [log level definition](#log-levels--log-level-definition). For styling logs in the terminal, each log level definition exposes a `terminal` property that is an array of [Chalk](https://github.com/chalk/chalk) style functions. This section contains a breakdown of what those default styles are as well as a list of possible values for the chalk styles.
+Although Adze comes with some pretty default styles, all logs within Adze can have their styling customized. Default log level styling is a combination of the `baseStyle` property plus the `style` property on its [log level definition](#log-levels--log-level-definition). For styling logs in the terminal, each log level definition exposes a `terminal` property that is an array of [Chalk](https://github.com/chalk/chalk) style functions. This section contains a breakdown of what those default styles are as well as a list of possible values for the chalk styles.
 
 ### Default Browser Styles
 
@@ -176,7 +178,7 @@ _NOTE: The default styles use [template string interpolation](https://developer.
 
 Adze styling for the terminal makes use of a library named [Chalk](https://github.com/chalk/chalk). Chalk exposes several formatting functions for terminal text styling that Adze exposes in its configuration.
 
-_NOTE: [Chalk](https://github.com/chalk/chalk#chalklevel) is what Adze uses under the hood for terminal coloring. Because terminals differ in their color fidelity, Chalk exposes a setting allowing you to specify your fidelity. Adze is basic with its colors so the low level of 1 is sufficient, however, you can change it to your liking with the `terminal_color_fidelity` option described in the [Adze Configuration](#adze-configuration) section above. Please refer to the [Chalk](https://github.com/chalk/chalk#chalklevel) docs for information about what the fidelity levels mean._
+_NOTE: [Chalk](https://github.com/chalk/chalk#chalklevel) is what Adze uses under the hood for terminal coloring. Because terminals differ in their color fidelity, Chalk exposes a setting allowing you to specify your fidelity. Adze is basic with its colors so the low level of 1 is sufficient, however, you can change it to your liking with the `terminalColorFidelity` option described in the [Adze Configuration](#adze-configuration) section above. Please refer to the [Chalk](https://github.com/chalk/chalk#chalklevel) docs for information about what the fidelity levels mean._
 
 #### Default Level Styles
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -49,11 +49,9 @@ As stated above, Adze offers an easy to use, chainable API. To create a log you 
 ```typescript
 import { adze } from 'adze';
 
-adze({ use_emoji: true }).ns('tix-456').log('Example log');
+adze({ useEmoji: true }).ns('tix-456').log('Example log');
 ```
 
 The output of this would look like the following:
 
 ![Preview of Adze logs](./examples/api_example_output.png)
-
-

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -23,14 +23,18 @@ As you may already be aware there are a number of other good JS libraries out th
 Here is a list of the features that Adze provides:
 
 - First-class TypeScript support
-- Runs in both the browser and node
-- A fluent, chainable API for creating logs
-- Log Listeners that empower you to do with your logs as you wish
-- Annotate your logs with namespaces, labels, and other meta data
+- Multi-environment support for the Browser and Node
+- Wraps and extends the entire standard API
+- A fluent, chainable API
+- Log Listeners for capturing log data
+- Log annotation namespaces, labels, and other meta data
 - Attractive styling (EMOJI'S INCLUDED and consistent across major browsers)
 - Everything is configurable
-- Create custom log levels
-- A global log store for recalling logs and overriding configuration
+- Enables completely custom log levels
+- A global log store for recalling logs and overriding configuration (supports micro-frontends and modules)
+- Support for Mapped Diagnostic Context
+- Convenient unit testing environment controls
+- Advanced Log Filtering
 - and much more...
 
 Beyond the new features that Adze provides you, it also wraps the entire console web standard.

--- a/docs/guide/adze-concepts.md
+++ b/docs/guide/adze-concepts.md
@@ -73,7 +73,7 @@ createShed();
 
 // Let's create an Adze configuration
 const cfg = {
-  log_level: 1,
+  logLevel: 1,
 };
 
 // Now we'll create a new factory using seal
@@ -93,6 +93,26 @@ log().log("I won't display because my log level is too high.");
 ![common usage example with seal](./examples/common-usage-example.png)
 
 ![common usage terminal example with seal](./examples/common-usage-terminal-example.png)
+
+## Standard Output (stdout)
+
+When writing adze logs in a Node environment there may be times where logs in stdout need to be unstyled to avoid styling artifacts polluting the log strings. Adze provides a simple [configuration option](/config/#adze-configuration) to turn off styling.
+
+### Example
+
+```javascript
+// ----- setup.js ----- //
+import { adze } from 'adze';
+
+// Let's create a new unstyled log factory using seal
+export const stdout = adze({ unstyled: true }).seal();
+
+// ----- elsewhere.js ----- //
+import { stdout } from '~/setup.js';
+
+// And now we can create new unstyled logs using our unstyled factory
+stdout().error('An error occurred! This log has no styles applied.');
+```
 
 ## Filtering
 

--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -24,7 +24,7 @@ type Collection = BaseLog[];
 import { adze, createShed } from 'adze';
 
 // Let's create a log bundle
-const bundled = bundle(adze({ use_emoji: true }));
+const bundled = bundle(adze({ useEmoji: true }));
 
 bundled().label('collect').error('This is an error!');
 bundled().label('collect').info('A bundled log with namespaces.');

--- a/docs/guide/default-terminators.md
+++ b/docs/guide/default-terminators.md
@@ -43,7 +43,7 @@ import { adze } from 'adze';
 
 adze().alert('Something went horribly wrong!');
 // With emoji's enabled
-adze({ use_emoji: true }).alert('Something went horribly wrong!');
+adze({ useEmoji: true }).alert('Something went horribly wrong!');
 ```
 
 ### Output
@@ -77,7 +77,7 @@ import { adze } from 'adze';
 
 adze().error('An error occurred!');
 // With emoji's enabled
-adze({ use_emoji: true }).error('An error occurred!');
+adze({ useEmoji: true }).error('An error occurred!');
 ```
 
 ### Output
@@ -111,7 +111,7 @@ import { adze } from 'adze';
 
 adze().warn("I'm warning you!");
 // With emoji's enabled
-adze({ use_emoji: true }).warn("I'm warning you!");
+adze({ useEmoji: true }).warn("I'm warning you!");
 ```
 
 ### Output
@@ -145,7 +145,7 @@ import { adze } from 'adze';
 
 adze().info('App information');
 // With emoji's enabled
-adze({ use_emoji: true }).info('App information');
+adze({ useEmoji: true }).info('App information');
 ```
 
 ### Output
@@ -179,7 +179,7 @@ import { adze } from 'adze';
 
 adze().fail('An operation failed to execute!');
 // With emoji's enabled
-adze({ use_emoji: true }).fail('An operation failed to execute!');
+adze({ useEmoji: true }).fail('An operation failed to execute!');
 ```
 
 ### Output
@@ -213,7 +213,7 @@ import { adze } from 'adze';
 
 adze().success('An operation was successful!');
 // With emoji's enabled
-adze({ use_emoji: true }).success('An operation was successful!');
+adze({ useEmoji: true }).success('An operation was successful!');
 ```
 
 ### Output
@@ -247,7 +247,7 @@ import { adze } from 'adze';
 
 adze().log('Logging a message.');
 // With emoji's enabled
-adze({ use_emoji: true }).log('Logging a message.');
+adze({ useEmoji: true }).log('Logging a message.');
 ```
 
 ### Output
@@ -281,7 +281,7 @@ import { adze } from 'adze';
 
 adze().debug('Debugging an issue.');
 // With emoji's enabled
-adze({ use_emoji: true }).debug('Debugging an issue.');
+adze({ useEmoji: true }).debug('Debugging an issue.');
 ```
 
 ### Output
@@ -315,7 +315,7 @@ import { adze } from 'adze';
 
 adze().verbose('Logging some extreme detail.');
 // With emoji's enabled
-adze({ use_emoji: true }).verbose('Logging some extreme detail.');
+adze({ useEmoji: true }).verbose('Logging some extreme detail.');
 ```
 
 ### Output

--- a/docs/guide/factories.md
+++ b/docs/guide/factories.md
@@ -12,11 +12,11 @@ Here are a few examples of some patterns that you can use:
 import { adze } from 'adze';
 
 // Here we are creating a log with a configuration that will only apply to this instance
-adze({ use_emoji: true }).log('Hello World with emoji!');
+adze({ useEmoji: true }).log('Hello World with emoji!');
 
 // But... what if we want to apply the same configuration to multiple logs?
 const cfg = {
-  use_emoji: true,
+  useEmoji: true,
 };
 
 adze(cfg).log('A log with emoji enabled.');
@@ -51,7 +51,7 @@ class BaseLog {
 import { adze } from 'adze';
 
 // Let's seal a configuration and namespace into a new log factory
-const log = adze({ use_emoji: true }).ns('my-project').seal();
+const log = adze({ useEmoji: true }).ns('my-project').seal();
 
 /* Now we can create new logs from our factory that enable emoji's and all
  * have the 'my-project' namespace! */

--- a/docs/guide/filtering-and-utility-functions.md
+++ b/docs/guide/filtering-and-utility-functions.md
@@ -21,7 +21,7 @@ function filterCollection(
 import { adze, bundle, filterCollection, rerender } from 'adze';
 
 // Let's create a bundle so we can collect our logs
-const bundled = bundle(adze({ use_emoji: true }));
+const bundled = bundle(adze({ useEmoji: true }));
 
 bundled().ns('foo').error('This is an error!');
 bundled().label('bar').info('This is some info.');
@@ -46,7 +46,7 @@ import { adze, createShed, filterCollection, rerender } from 'adze';
 const shed = createShed();
 
 // Let's create a new log factory
-const log = adze({ use_emoji: true }).seal();
+const log = adze({ useEmoji: true }).seal();
 
 log().ns('foo').error('This is an error!');
 log().label('bar').info('This is some info.');
@@ -87,7 +87,7 @@ function filterLabel(collection: Collection = [], label: string): Collection;
 import { adze, bundle, filterLabel, rerender } from 'adze';
 
 // Let's create a bundle so we can collect our logs
-const bundled = bundle(adze({ use_emoji: true }));
+const bundled = bundle(adze({ useEmoji: true }));
 
 bundled().label('foo').error('This is an error!');
 bundled().label('bar').info('This is some info.');
@@ -109,7 +109,7 @@ import { adze, createShed, filterLabel, rerender } from 'adze';
 const shed = createShed();
 
 // Let's create a new log factory
-const log = adze({ use_emoji: true }).seal();
+const log = adze({ useEmoji: true }).seal();
 
 log().label('foo').error('This is an error!');
 log().label('bar').info('This is some info.');
@@ -150,7 +150,7 @@ function filterLevel(
 import { adze, bundle, filterLevel, rerender } from 'adze';
 
 // Let's create a bundle so we can collect our logs
-const bundled = bundle(adze({ use_emoji: true }));
+const bundled = bundle(adze({ useEmoji: true }));
 
 bundled().error('This is an error!');
 bundled().info('This is some info.');
@@ -172,7 +172,7 @@ import { adze, createShed, filterLevel, rerender } from 'adze';
 const shed = createShed();
 
 // Let's create a new log factory
-const log = adze({ use_emoji: true }).seal();
+const log = adze({ useEmoji: true }).seal();
 
 log().error('This is an error!');
 log().info('This is some info.');
@@ -210,7 +210,7 @@ function filterNamespace(collection: Collection = [], ns: string[]): Collection;
 import { adze, bundle, filterNamespace, rerender } from 'adze';
 
 // Let's create a bundle so we can collect our logs
-const bundled = bundle(adze({ use_emoji: true }));
+const bundled = bundle(adze({ useEmoji: true }));
 
 bundled().ns('bar').error('This is an error!');
 bundled().ns(['foo', 'bar']).info('This is some info.');
@@ -232,7 +232,7 @@ import { adze, createShed, filterNamespace, rerender } from 'adze';
 const shed = createShed();
 
 // Let's create a new log factory
-const log = adze({ use_emoji: true }).seal();
+const log = adze({ useEmoji: true }).seal();
 
 log().ns('bar').error('This is an error!');
 log().ns(['foo', 'bar']).info('This is some info.');

--- a/docs/guide/modifiers.md
+++ b/docs/guide/modifiers.md
@@ -36,7 +36,7 @@ adze()
   .log('X does not equal 2');
 
 // Let's look at the output with emoji's enabled
-adze({ use_emoji: true })
+adze({ useEmoji: true })
   .assert(x === y)
   .log('X does not equal Y');
 ```
@@ -603,7 +603,7 @@ adze()
   .log('X does not equal Y');
 
 // Let's look at the output with emoji's enabled
-adze({ use_emoji: true })
+adze({ useEmoji: true })
   .test(y === 3)
   .log('Y equals 3');
 ```
@@ -648,7 +648,7 @@ for (let i = 0; i < 10000; i += 1) {
 adze().label('loop').timeEnd.log('Performance of our loop.');
 
 // Let's see the output with emoji's
-adze({ use_emoji: true }).label('loop').timeEnd.log('Performance of our loop.');
+adze({ useEmoji: true }).label('loop').timeEnd.log('Performance of our loop.');
 ```
 
 ### Output
@@ -691,7 +691,7 @@ for (let i = 0; i < 10000; i += 1) {
 adze().label('loop').timeEnd.log('Performance of our loop.');
 
 // Let's see the output with emoji's
-adze({ use_emoji: true }).label('loop').timeEnd.log('Performance of our loop.');
+adze({ useEmoji: true }).label('loop').timeEnd.log('Performance of our loop.');
 ```
 
 ### Output
@@ -729,7 +729,7 @@ for (let i = 0; i < 10000; i += 1) {
 adze().timeNow.log('Recording the time ellapsed since page load.');
 
 // Let's see what it looks like with emoji's enabled.
-adze({ use_emoji: true }).timeNow.log(
+adze({ useEmoji: true }).timeNow.log(
   'Recording the time ellapsed since page load.'
 );
 ```

--- a/docs/guide/other-terminators.md
+++ b/docs/guide/other-terminators.md
@@ -103,9 +103,9 @@ import { adze } from 'adze';
 
 // Create our Adze configuration
 const cfg = {
-  log_level: Infinity,
-  use_emoji: true,
-  custom_levels: {
+  logLevel: Infinity,
+  useEmoji: true,
+  customLevels: {
     leetLevel: {
       level: 1337,
       method: 'log',

--- a/docs/guide/shed-concepts.md
+++ b/docs/guide/shed-concepts.md
@@ -50,8 +50,8 @@ const level = ENV.level; // <- Env.level currently is set to 0.
 
 // Let's create a shed to globally control our modules
 createShed({
-  global_cfg: {
-    log_level: level, // <- level is 0 so all logs except alert's are hidden
+  globalCfg: {
+    logLevel: level, // <- level is 0 so all logs except alert's are hidden
   },
 });
 

--- a/docs/guide/using-shed.md
+++ b/docs/guide/using-shed.md
@@ -79,15 +79,15 @@ class Shed {
 import { adze, createShed } from 'adze';
 
 const shed = createShed({
-  cache_limit: 300,
+  cacheLimit: 300,
 });
 
 // Override the cache limit
 shed.cacheLimit = 500;
 
 // Let's get the cache limit
-const cache_limit = shed.cacheLimit;
-// cache_limit => 500
+const cacheLimit = shed.cacheLimit;
+// cacheLimit => 500
 ```
 
 ## cacheSize
@@ -137,15 +137,15 @@ import { adze, createShed } from 'adze';
 
 // Creating a Shed instance with no config overrides
 const shed = createShed({
-  global_cfg: {
-    log_level: 0,
+  globalCfg: {
+    logLevel: 0,
   },
 });
 
 // Now we'll override the configuration
 shed.config = {
-  global_cfg: {
-    log_level: 3,
+  globalCfg: {
+    logLevel: 3,
   },
 };
 ```
@@ -316,8 +316,8 @@ import { adze, createShed } from 'adze';
 
 // Creating a Shed instance with no config overrides
 const shed = createShed({
-  global_cfg: {
-    log_level: 0,
+  globalCfg: {
+    logLevel: 0,
   },
 });
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ features:
 ---
 
 ::: slot typescript-support
+
 ## First Class TypeScript Support
 
 Adze is built with TypeScript from the ground up. Take advantage of all of the benefits of
@@ -29,6 +30,7 @@ using TypeScript with your app's logs.
 :::
 
 ::: slot chainable-api
+
 ## A Fluent, Chainable API
 
 Writing your logs should feel natural which is why Adze chose to implement a [chainable
@@ -37,9 +39,11 @@ API](/guide/adze-concepts.md) that feels very much like the standard console API
 ```typescript
 adze().namespace('Hello').count.log('World!');
 ```
+
 :::
 
 ::: slot everything-configurable
+
 ## Everything is Configurable
 
 Setup your logging exactly how you need it. [Everything with Adze is configurable](/config), from
@@ -47,11 +51,13 @@ the default log levels down to the emoji's your logs use. You can even create co
 custom log levels. How you use Adze is up to you.
 
 ```typescript
-adze({ use_emoji: true }).success("I'm configured to use emoji's!");
+adze({ useEmoji: true }).success("I'm configured to use emoji's!");
 ```
+
 :::
 
 ::: slot browser-and-node
+
 ## Supports Browser and Node Environments
 
 Run code containing your adze logs seamlessly [in both the browser and node](/guide/installation.md) environments.
@@ -59,10 +65,11 @@ There is no extra configuration required.
 :::
 
 ::: slot shed
+
 ## Global Store and Overrides
 
 Adze comes with a component called [Shed](/guide/shed-concepts.md) which provides a global store for your logs. With the global
-store you can recall logs from an in-memory cache and override log configurations; effectively 
+store you can recall logs from an in-memory cache and override log configurations; effectively
 enabling micro-service and micro-frontend architectures.
 :::
 
@@ -76,6 +83,6 @@ Find Adze on [GitHub](https://github.com/AJStacy/adze)
 
 ## And much more...
 
-To learn more about Adze and how to use it in your project, take a look at the [Guide](/guide) and 
+To learn more about Adze and how to use it in your project, take a look at the [Guide](/guide) and
 watch the introduction video.
 :::

--- a/readme.md
+++ b/readme.md
@@ -24,14 +24,18 @@ As you may already be aware there are a number of other good JS libraries out th
 Here is a list of the features that Adze provides:
 
 - First-class TypeScript support
-- Runs in both the browser and node
-- A fluent, chainable API for creating logs
-- Log Listeners that empower you to do with your logs as you wish
-- Annotate your logs with namespaces, labels, and other meta data
+- Multi-environment support for the Browser and Node
+- Wraps and extends the entire standard API
+- A fluent, chainable API
+- Log Listeners for capturing log data
+- Log annotation namespaces, labels, and other meta data
 - Attractive styling (EMOJI'S INCLUDED and consistent across major browsers)
 - Everything is configurable
-- Create custom log levels
-- A global log store for recalling logs and overriding configuration
+- Enables completely custom log levels
+- A global log store for recalling logs and overriding configuration (supports micro-frontends and modules)
+- Support for Mapped Diagnostic Context
+- Convenient unit testing environment controls
+- Advanced Log Filtering
 - and much more...
 
 Beyond the new features that Adze provides you, it also wraps the entire console web standard.
@@ -50,7 +54,7 @@ As stated above, Adze offers an easy to use, chainable API. To create a log you 
 ```typescript
 import { adze } from 'adze';
 
-adze({ use_emoji: true }).ns('tix-456').log('Example log');
+adze({ useEmoji: true }).ns('tix-456').log('Example log');
 ```
 
 The output of this would look like the following:
@@ -91,7 +95,7 @@ For more information about configuring TypeScript, go to [https://www.typescript
   "compilerOptions": {
     // ...your other options
     "lib": ["DOM"],
-    "esModuleInterop": true,
+    "esModuleInterop": true
   }
 }
 ```

--- a/src/_contracts/Configuration.ts
+++ b/src/_contracts/Configuration.ts
@@ -16,13 +16,14 @@ export type ConsoleMethod =
   | 'dirxml';
 
 export interface Defaults {
-  log_level: number;
-  use_emoji: boolean;
-  terminal_color_fidelity: 0 | 1 | 2 | 3;
-  capture_stacktrace: boolean;
-  base_style: string;
-  log_levels: LogLevels;
-  custom_levels: LogLevels;
+  logLevel: number;
+  useEmoji: boolean;
+  terminalColorFidelity: 0 | 1 | 2 | 3;
+  captureStacktrace: boolean;
+  stdout: boolean;
+  baseStyle: string;
+  logLevels: LogLevels;
+  customLevels: LogLevels;
   filters: AdzeFilters;
   meta: {
     [key: string]: unknown;
@@ -44,7 +45,7 @@ export interface LogLevelDefinition {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Configuration
-  extends Partial<Omit<Defaults, 'filters' | 'log_levels'>> {
-  log_levels?: RecursivePartial<LogLevels>;
+  extends Partial<Omit<Defaults, 'filters' | 'logLevels'>> {
+  logLevels?: RecursivePartial<LogLevels>;
   filters?: UserAdzeFilters;
 }

--- a/src/_contracts/Configuration.ts
+++ b/src/_contracts/Configuration.ts
@@ -20,7 +20,7 @@ export interface Defaults {
   useEmoji: boolean;
   terminalColorFidelity: 0 | 1 | 2 | 3;
   captureStacktrace: boolean;
-  stdout: boolean;
+  unstyled: boolean;
   baseStyle: string;
   logLevels: LogLevels;
   customLevels: LogLevels;

--- a/src/_contracts/Shed.ts
+++ b/src/_contracts/Shed.ts
@@ -16,13 +16,12 @@ export type ListenerCallback = (
 ) => void;
 
 export interface ShedConfig {
-  cache_limit: number;
-  global_cfg: Defaults | null;
+  cacheLimit: number;
+  globalCfg: Defaults | null;
 }
 
-export interface ShedUserConfig
-  extends Partial<Omit<ShedConfig, 'global_cfg'>> {
-  global_cfg?: Configuration | null;
+export interface ShedUserConfig extends Partial<Omit<ShedConfig, 'globalCfg'>> {
+  globalCfg?: Configuration | null;
 }
 
 export interface LabelData {

--- a/src/_defaults/defaults.ts
+++ b/src/_defaults/defaults.ts
@@ -2,15 +2,16 @@ import { Env } from '../env';
 import { Defaults } from '../_contracts';
 
 export const defaults: Defaults = {
-  log_level: 8,
-  use_emoji: false,
-  capture_stacktrace: false,
-  terminal_color_fidelity: 1,
-  base_style:
+  logLevel: 8,
+  useEmoji: false,
+  captureStacktrace: false,
+  terminalColorFidelity: 1,
+  stdout: false,
+  baseStyle:
     'font-size: 10px; font-weight: bold; border-radius: 0 10px 10px 0; border-width: 1px; border-style: solid;',
-  custom_levels: {},
+  customLevels: {},
   meta: {},
-  log_levels: {
+  logLevels: {
     alert: {
       level: 0,
       style: `padding-right: ${

--- a/src/_defaults/defaults.ts
+++ b/src/_defaults/defaults.ts
@@ -6,7 +6,7 @@ export const defaults: Defaults = {
   useEmoji: false,
   captureStacktrace: false,
   terminalColorFidelity: 1,
-  stdout: false,
+  unstyled: false,
   baseStyle:
     'font-size: 10px; font-weight: bold; border-radius: 0 10px 10px 0; border-width: 1px; border-style: solid;',
   customLevels: {},

--- a/src/_defaults/shed_defaults.ts
+++ b/src/_defaults/shed_defaults.ts
@@ -1,6 +1,6 @@
 import { ShedConfig } from '../_contracts';
 
 export const shed_defaults: ShedConfig = {
-  cache_limit: 300,
-  global_cfg: null,
+  cacheLimit: 300,
+  globalCfg: null,
 };

--- a/src/conditions/conditions.ts
+++ b/src/conditions/conditions.ts
@@ -8,7 +8,7 @@ import { getSearchParams } from '../util';
  */
 export function allowed(data: FinalLogData): boolean {
   return (
-    levelActive(data.definition, data.cfg.log_level) &&
+    levelActive(data.definition, data.cfg.logLevel) &&
     notTestEnv() &&
     passesFilters(data.cfg, data)
   );

--- a/src/log/BaseLog.ts
+++ b/src/log/BaseLog.ts
@@ -679,7 +679,7 @@ export class BaseLog {
    * Generates a terminating log method the specified log level name.
    */
   private logMethod(levelName: string, args: unknown[]): TerminatedLog<this> {
-    return this.terminate(this.getDefinition('log_levels', levelName), args);
+    return this.terminate(this.getDefinition('logLevels', levelName), args);
   }
 
   /**
@@ -687,14 +687,14 @@ export class BaseLog {
    * log level by key as the format for the log.
    */
   private customMethod(lvlName: string, args: unknown[]): TerminatedLog<this> {
-    return this.terminate(this.getDefinition('custom_levels', lvlName), args);
+    return this.terminate(this.getDefinition('customLevels', lvlName), args);
   }
 
   /**
    * Gets the log level definition from the log configuration.
    */
   private getDefinition(
-    type: 'log_levels' | 'custom_levels',
+    type: 'logLevels' | 'customLevels',
     levelName: string
   ): LogLevelDefinition | undefined {
     const definition = this.cfg[type][levelName];
@@ -719,7 +719,7 @@ export class BaseLog {
         this._level = def.level;
         this.definition = def;
         this.timestamp = timestamp();
-        this.stacktrace = this.cfg.capture_stacktrace ? stacktrace() : null;
+        this.stacktrace = this.cfg.captureStacktrace ? stacktrace() : null;
 
         // Set this log data to a variable for type checking
         const log_data = this.data;

--- a/src/printers/BrowserPrinter.ts
+++ b/src/printers/BrowserPrinter.ts
@@ -15,13 +15,15 @@ export class BrowserPrinter extends SharedPrinter {
   public printLog(): LogRender {
     const method = this.data.definition.method;
     const leader = this.fLeader();
-    const style = this.data.cfg.baseStyle + this.data.definition.style;
+    const style = this.unstyled
+      ? ''
+      : this.data.cfg.baseStyle + this.data.definition.style;
     const meta = this.fMeta();
 
-    const renderArgs =
-      meta === ''
-        ? [leader, style, ...this.data.args]
-        : [leader, style, meta, ...this.data.args];
+    // Assemble the args
+    const renderArgsRaw = [leader, style, meta];
+    const renderArgsFiltered = renderArgsRaw.filter((val) => val !== '');
+    const renderArgs = [...renderArgsFiltered, ...this.data.args];
 
     return [method, renderArgs];
   }
@@ -79,17 +81,16 @@ export class BrowserPrinter extends SharedPrinter {
    * the log level name, and the number of arguments being printed.
    */
   public fLeader(): string {
-    return ` %c${this.fEmoji()} ${this.fName()}(${this.data.args.length})`;
+    const styleFlag = this.unstyled ? '' : '%c';
+    const argCount = this.data.args.length;
+    return ` ${styleFlag}${this.fEmoji()} ${this.fName()}(${argCount})`;
   }
 
   /**
    * Adds the emoji to the log leader if enabled.
    */
   public fEmoji(): string {
-    const global_use_emoji = this.env.global.$shed?.overrides?.useEmoji;
-    return global_use_emoji || this.use_emoji
-      ? ` ${this.data.definition.emoji}`
-      : '';
+    return this.use_emoji ? ` ${this.data.definition.emoji}` : '';
   }
 
   /**
@@ -118,11 +119,7 @@ export class BrowserPrinter extends SharedPrinter {
     const timeEllapsed = this.data.label?.timeEllapsed;
     const labelTxt = `${timeNow ?? timeEllapsed ?? ''}`;
 
-    const globalUseEmoji = this.env.global.$shed?.overrides?.useEmoji;
-
-    return labelTxt !== ''
-      ? ` (${globalUseEmoji || this.use_emoji ? '⏱' : ''}${labelTxt}) `
-      : '';
+    return labelTxt !== '' ? ` (${this.use_emoji ? '⏱' : ''}${labelTxt}) ` : '';
   }
 
   /**

--- a/src/printers/BrowserPrinter.ts
+++ b/src/printers/BrowserPrinter.ts
@@ -15,29 +15,29 @@ export class BrowserPrinter extends SharedPrinter {
   public printLog(): LogRender {
     const method = this.data.definition.method;
     const leader = this.fLeader();
-    const style = this.data.cfg.base_style + this.data.definition.style;
+    const style = this.data.cfg.baseStyle + this.data.definition.style;
     const meta = this.fMeta();
 
-    const render_args =
+    const renderArgs =
       meta === ''
         ? [leader, style, ...this.data.args]
         : [leader, style, meta, ...this.data.args];
 
-    return [method, render_args];
+    return [method, renderArgs];
   }
 
   /**
    * The method for rendering group logs.
    */
   public printGroup(): LogRender {
-    const partial_args = [
+    const partialArgs = [
       this.fLeader(),
-      this.data.cfg.base_style + this.data.definition.style,
+      this.data.cfg.baseStyle + this.data.definition.style,
     ];
     const render_args =
       typeof this.data.args[0] === 'string'
-        ? [...partial_args, this.data.args[0]]
-        : partial_args;
+        ? [...partialArgs, this.data.args[0]]
+        : partialArgs;
 
     return ['group', render_args];
   }
@@ -48,7 +48,7 @@ export class BrowserPrinter extends SharedPrinter {
   public printGroupCollapsed(): LogRender {
     const partial_args = [
       this.fLeader(),
-      this.data.cfg.base_style + this.data.definition.style,
+      this.data.cfg.baseStyle + this.data.definition.style,
     ];
     const render_args =
       typeof this.data.args[0] === 'string'
@@ -86,7 +86,7 @@ export class BrowserPrinter extends SharedPrinter {
    * Adds the emoji to the log leader if enabled.
    */
   public fEmoji(): string {
-    const global_use_emoji = this.env.global.$shed?.overrides?.use_emoji;
+    const global_use_emoji = this.env.global.$shed?.overrides?.useEmoji;
     return global_use_emoji || this.use_emoji
       ? ` ${this.data.definition.emoji}`
       : '';
@@ -116,12 +116,12 @@ export class BrowserPrinter extends SharedPrinter {
   public fTime(): string {
     const timeNow = this.data.label.timeNow ?? this.data.timeNow;
     const timeEllapsed = this.data.label?.timeEllapsed;
-    const label_txt = `${timeNow ?? timeEllapsed ?? ''}`;
+    const labelTxt = `${timeNow ?? timeEllapsed ?? ''}`;
 
-    const global_use_emoji = this.env.global.$shed?.overrides?.use_emoji;
+    const globalUseEmoji = this.env.global.$shed?.overrides?.useEmoji;
 
-    return label_txt !== ''
-      ? ` (${global_use_emoji || this.use_emoji ? '⏱' : ''}${label_txt}) `
+    return labelTxt !== ''
+      ? ` (${globalUseEmoji || this.use_emoji ? '⏱' : ''}${labelTxt}) `
       : '';
   }
 

--- a/src/printers/NodePrinter.ts
+++ b/src/printers/NodePrinter.ts
@@ -73,7 +73,7 @@ export class NodePrinter extends SharedPrinter {
     return applyChalkStyles(
       padded_leader,
       this.data.definition.terminal,
-      this.data.cfg.terminal_color_fidelity
+      this.data.cfg.terminalColorFidelity
     );
   }
 
@@ -122,7 +122,7 @@ export class NodePrinter extends SharedPrinter {
     const timeEllapsed = this.data.label.timeEllapsed;
     const label_txt = `${timeNow ?? timeEllapsed ?? ''}`;
 
-    const use_emoji_global = this.env.global.$shed?.overrides?.use_emoji;
+    const use_emoji_global = this.env.global.$shed?.overrides?.useEmoji;
 
     return label_txt !== ''
       ? `(${use_emoji_global || this.use_emoji ? '⏱' : ''}${label_txt}) `

--- a/src/printers/NodePrinter.ts
+++ b/src/printers/NodePrinter.ts
@@ -65,13 +65,18 @@ export class NodePrinter extends SharedPrinter {
     const padding = this.use_emoji ? 14 + emoji.length : 14;
 
     // If the leader length is greater than the padding, add a space to the end for pretty formatting
-    const leader_raw = `${emoji} ${this.fName()}(${this.data.args.length})`;
-    const leader = leader_raw.length >= padding ? `${leader_raw} ` : leader_raw;
+    const leaderRaw = `${emoji} ${this.fName()}(${this.data.args.length})`;
+    const leader = leaderRaw.length >= padding ? `${leaderRaw} ` : leaderRaw;
 
-    const padded_leader = this.addPadding(leader, padding);
+    const paddedLeader = this.addPadding(leader, padding);
 
+    // If the log instance is configured as unstyled, prevent applying chalk styles.
+    if (this.data.cfg.unstyled) {
+      return paddedLeader;
+    }
+    //
     return applyChalkStyles(
-      padded_leader,
+      paddedLeader,
       this.data.definition.terminal,
       this.data.cfg.terminalColorFidelity
     );
@@ -120,13 +125,9 @@ export class NodePrinter extends SharedPrinter {
   private fTime(): string {
     const timeNow = this.data.label.timeNow ?? this.data.timeNow;
     const timeEllapsed = this.data.label.timeEllapsed;
-    const label_txt = `${timeNow ?? timeEllapsed ?? ''}`;
+    const labelTxt = `${timeNow ?? timeEllapsed ?? ''}`;
 
-    const use_emoji_global = this.env.global.$shed?.overrides?.useEmoji;
-
-    return label_txt !== ''
-      ? `(${use_emoji_global || this.use_emoji ? '⏱' : ''}${label_txt}) `
-      : '';
+    return labelTxt !== '' ? `(${this.use_emoji ? '⏱' : ''}${labelTxt}) ` : '';
   }
 
   /**

--- a/src/printers/SharedPrinter.ts
+++ b/src/printers/SharedPrinter.ts
@@ -13,9 +13,14 @@ export class SharedPrinter {
 
   get use_emoji(): boolean {
     return (
-      this.env.global.$shed?.overrides?.useEmoji === true ||
-      this.data.cfg.useEmoji === true
+      (this.env.global.$shed?.overrides?.useEmoji === true &&
+        !this.env.global.$shed?.overrides?.unstyled === false) ||
+      (this.data.cfg.useEmoji === true && this.data.cfg.unstyled === false)
     );
+  }
+
+  get unstyled(): boolean {
+    return this.data.cfg.unstyled;
   }
 
   // ------ Shared Formatters ------- //

--- a/src/printers/SharedPrinter.ts
+++ b/src/printers/SharedPrinter.ts
@@ -13,8 +13,8 @@ export class SharedPrinter {
 
   get use_emoji(): boolean {
     return (
-      this.env.global.$shed?.overrides?.use_emoji === true ||
-      this.data.cfg.use_emoji === true
+      this.env.global.$shed?.overrides?.useEmoji === true ||
+      this.data.cfg.useEmoji === true
     );
   }
 

--- a/src/shed/Shed.ts
+++ b/src/shed/Shed.ts
@@ -70,7 +70,7 @@ export class Shed {
    * Store a log in the Shed.
    */
   public store(log: BaseLog): void {
-    if (this.cacheSize < this.cfg.cache_limit) {
+    if (this.cacheSize < this.cfg.cacheLimit) {
       this._cache = this._cache.concat([log]);
     }
   }
@@ -79,14 +79,14 @@ export class Shed {
    * Sets the limit for the maximum number of logs that Shed will cache.
    */
   public set cacheLimit(limit: number) {
-    this.cfg.cache_limit = limit;
+    this.cfg.cacheLimit = limit;
   }
 
   /**
    * Gets the limit for the maximum number of logs that Shed will cache.
    */
   public get cacheLimit(): number {
-    return this.cfg.cache_limit;
+    return this.cfg.cacheLimit;
   }
 
   /**
@@ -101,7 +101,7 @@ export class Shed {
    * This is useful for recalling logs and applying filters.
    */
   public getCollection(levels: LevelFilter): Collection {
-    const lvls = formatLevels(levels, this.cfg.global_cfg);
+    const lvls = formatLevels(levels, this.cfg.globalCfg);
     return this._cache.reduce((acc, log) => {
       return acc.concat(lvls.includes(log.level ?? Infinity) ? [log] : []);
     }, [] as Collection);
@@ -111,14 +111,14 @@ export class Shed {
    * Indicates whether this Shed instance has global Adze config overrides set.
    */
   public get hasOverrides(): boolean {
-    return this.cfg.global_cfg !== null;
+    return this.cfg.globalCfg !== null;
   }
 
   /**
    * Returns the current value of the global Adze configuration overrides.
    */
   public get overrides(): Configuration | null {
-    return this.cfg.global_cfg;
+    return this.cfg.globalCfg;
   }
 
   /**
@@ -134,9 +134,9 @@ export class Shed {
    * filters for performance reasons.
    */
   private formatConfig(cfg: ShedUserConfig | undefined): ShedConfig {
-    const global_cfg = cfg?.global_cfg ?? null;
+    const globalCfg = cfg?.globalCfg ?? null;
 
-    const cfg_global_defaults = { ...cfg, global_cfg };
+    const cfg_global_defaults = { ...cfg, globalCfg };
     return defaultsDeep(cfg_global_defaults, shed_defaults) as ShedConfig;
   }
 
@@ -174,7 +174,7 @@ export class Shed {
     levels: LevelFilter,
     cb: ListenerCallback
   ): ListenerLocations {
-    const lvls = formatLevels(levels, this.cfg.global_cfg);
+    const lvls = formatLevels(levels, this.cfg.globalCfg);
     return lvls.map((lvl: number) => {
       // Get the map for the listeners of the given log level.
       const level_map = this.listenerBucket(lvl);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -50,7 +50,7 @@ export function isRange(val: unknown[]): val is Range {
  * Returns the highest level from the provided configuration.
  */
 export function getMaxLevel(cfg: Defaults | null): number {
-  return Math.max(...[8, ...levelsFromConfig(cfg?.custom_levels ?? {})]);
+  return Math.max(...[8, ...levelsFromConfig(cfg?.customLevels ?? {})]);
 }
 
 /**

--- a/test/adze.ts
+++ b/test/adze.ts
@@ -33,9 +33,9 @@ test('create a new logger with defaults', (t) => {
     t.is(emoji, cfg_emoji);
   };
 
-  Object.keys(cfg.log_levels).forEach((name) => {
-    t.truthy(Object.keys(defaults.log_levels).includes(name));
-    testLevel(cfg.log_levels[name], defaults.log_levels[name]);
+  Object.keys(cfg.logLevels).forEach((name) => {
+    t.truthy(Object.keys(defaults.logLevels).includes(name));
+    testLevel(cfg.logLevels[name], defaults.logLevels[name]);
   });
 
   // Test congruity of filters
@@ -44,7 +44,7 @@ test('create a new logger with defaults', (t) => {
 });
 
 test('prevents log render when the log level is lowered', (t) => {
-  const terminated = adze({ log_level: 5 }).log('testing');
+  const terminated = adze({ logLevel: 5 }).log('testing');
   t.truthy(terminated.log);
   t.is(terminated.render, null);
 });

--- a/test/browser/customize.ts
+++ b/test/browser/customize.ts
@@ -12,7 +12,7 @@ test('renders a custom log', (t) => {
   const style =
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const { log, render } = adze({
-    custom_levels: {
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',
@@ -28,7 +28,7 @@ test('renders a custom log', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c Custom(1)');
-    t.is(args[1], defaults.base_style + style);
+    t.is(args[1], defaults.baseStyle + style);
     t.is(args[2], 'This is a custom log.');
   } else {
     t.fail();
@@ -39,8 +39,8 @@ test('renders a custom log with emoji', (t) => {
   const style =
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const { log, render } = adze({
-    use_emoji: true,
-    custom_levels: {
+    useEmoji: true,
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',
@@ -56,7 +56,7 @@ test('renders a custom log with emoji', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c 🤪 Custom(1)');
-    t.is(args[1], defaults.base_style + style);
+    t.is(args[1], defaults.baseStyle + style);
     t.is(args[2], 'This is a custom log.');
   } else {
     t.fail();
@@ -68,10 +68,10 @@ test('renders a custom log with emoji', (t) => {
 // =========================
 
 test('renders a log with altered base style', (t) => {
-  const base_style =
+  const baseStyle =
     'font-size: 12px; font-weight: normal; border-radius: 0 5px 5px 0; border-width: 2px; border-style: dashed;';
   const t_log = adze({
-    base_style,
+    baseStyle,
   }).log('testing');
   t.truthy(t_log.log);
 
@@ -79,7 +79,7 @@ test('renders a log with altered base style', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'log');
     t.is(args[0], ' %c Log(1)');
-    t.is(args[1], base_style + defaults.log_levels.log.style);
+    t.is(args[1], baseStyle + defaults.logLevels.log.style);
     t.is(args[2], 'testing');
   } else {
     t.fail();

--- a/test/browser/customize.ts
+++ b/test/browser/customize.ts
@@ -85,3 +85,23 @@ test('renders a log with altered base style', (t) => {
     t.fail();
   }
 });
+
+// =========================
+// UNSTYLED FOR STDOUT
+// =========================
+
+test('renders an unstyled log', (t) => {
+  const unstyled = adze({ unstyled: true })
+    .label('unstyled')
+    .log('This log should have no style.');
+
+  t.truthy(unstyled.log);
+
+  if (unstyled.render) {
+    const [method, args] = unstyled.render;
+    t.is(method, 'log');
+    t.is(args[0], '  Log(1)');
+    t.is(args[1], '[unstyled] ');
+    t.is(args[2], 'This log should have no style.');
+  }
+});

--- a/test/browser/defaults-emoji.ts
+++ b/test/browser/defaults-emoji.ts
@@ -14,7 +14,7 @@ window.ADZE_ENV = 'dev';
 
 test('renders a alert log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).alert('testing');
   t.truthy(t_log.log);
 
@@ -22,7 +22,7 @@ test('renders a alert log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'error');
     t.is(args[0], ' %c 🚨 Alert(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.alert.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.alert.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -31,7 +31,7 @@ test('renders a alert log with emoji', (t) => {
 
 test('renders a error log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).error('testing');
   t.truthy(t_log.log);
 
@@ -39,7 +39,7 @@ test('renders a error log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'error');
     t.is(args[0], ' %c 🔥 Error(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.error.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.error.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -48,7 +48,7 @@ test('renders a error log with emoji', (t) => {
 
 test('renders a warn log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).warn('testing');
   t.truthy(t_log.log);
 
@@ -56,7 +56,7 @@ test('renders a warn log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'warn');
     t.is(args[0], ' %c 🔔 Warn(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.warn.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.warn.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -65,7 +65,7 @@ test('renders a warn log with emoji', (t) => {
 
 test('renders a info log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).info('testing');
   t.truthy(t_log.log);
 
@@ -73,7 +73,7 @@ test('renders a info log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c 📬 Info(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.info.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.info.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -82,7 +82,7 @@ test('renders a info log with emoji', (t) => {
 
 test('renders a fail log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).fail('testing');
   t.truthy(t_log.log);
 
@@ -90,7 +90,7 @@ test('renders a fail log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c ❌ Fail(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.fail.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.fail.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -99,7 +99,7 @@ test('renders a fail log with emoji', (t) => {
 
 test('renders a success log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).success('testing');
   t.truthy(t_log.log);
 
@@ -107,7 +107,7 @@ test('renders a success log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c 🎉 Success(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.success.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.success.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -116,7 +116,7 @@ test('renders a success log with emoji', (t) => {
 
 test('renders a log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).log('testing');
   t.truthy(t_log.log);
 
@@ -124,7 +124,7 @@ test('renders a log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'log');
     t.is(args[0], ' %c 📌 Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -133,7 +133,7 @@ test('renders a log with emoji', (t) => {
 
 test('renders a debug log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).debug('testing');
   t.truthy(t_log.log);
 
@@ -141,7 +141,7 @@ test('renders a debug log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'debug');
     t.is(args[0], ' %c 🐞 Debug(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.debug.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.debug.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -150,7 +150,7 @@ test('renders a debug log with emoji', (t) => {
 
 test('renders a verbose log with emoji', (t) => {
   const t_log = adze({
-    use_emoji: true,
+    useEmoji: true,
   }).verbose('testing');
   t.truthy(t_log.log);
 
@@ -158,7 +158,7 @@ test('renders a verbose log with emoji', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'debug');
     t.is(args[0], ' %c 💤 Verbose(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.verbose.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.verbose.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -169,8 +169,8 @@ test('renders a custom log with emoji', (t) => {
   const style =
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const { log, render } = adze({
-    use_emoji: true,
-    custom_levels: {
+    useEmoji: true,
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',
@@ -186,7 +186,7 @@ test('renders a custom log with emoji', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c 🤪 Custom(1)');
-    t.is(args[1], `${defaults.base_style}${style}`);
+    t.is(args[1], `${defaults.baseStyle}${style}`);
     t.is(args[2], 'This is a custom log.');
   } else {
     t.fail();

--- a/test/browser/defaults.ts
+++ b/test/browser/defaults.ts
@@ -18,7 +18,7 @@ test('renders a default alert log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'error');
     t.is(args[0], ' %c Alert(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.alert.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.alert.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -33,7 +33,7 @@ test('renders a default error log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'error');
     t.is(args[0], ' %c Error(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.error.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.error.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -48,7 +48,7 @@ test('renders a default warn log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'warn');
     t.is(args[0], ' %c Warn(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.warn.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.warn.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -63,7 +63,7 @@ test('renders a default info log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c Info(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.info.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.info.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -78,7 +78,7 @@ test('renders a default fail log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c Fail(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.fail.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.fail.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -93,7 +93,7 @@ test('renders a default success log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'info');
     t.is(args[0], ' %c Success(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.success.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.success.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -108,7 +108,7 @@ test('renders a default log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'log');
     t.is(args[0], ' %c Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -123,7 +123,7 @@ test('renders a default debug log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'debug');
     t.is(args[0], ' %c Debug(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.debug.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.debug.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();
@@ -138,7 +138,7 @@ test('renders a default verbose log', (t) => {
     const [method, args] = t_log.render;
     t.is(method, 'debug');
     t.is(args[0], ' %c Verbose(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.verbose.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.verbose.style}`);
     t.is(args[2], 'testing');
   } else {
     t.fail();

--- a/test/browser/modifiers/conditional.ts
+++ b/test/browser/modifiers/conditional.ts
@@ -20,7 +20,7 @@ test('log renders when assertion is false (fails)', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], 'Assertion failed:');
     t.is(args[3], 'Asserts that x is 3.');
   } else {
@@ -30,7 +30,7 @@ test('log renders when assertion is false (fails)', (t) => {
 
 test('log renders with emoji when assertion is false (fails)', (t) => {
   const x = 2;
-  const { render } = adze({ use_emoji: true })
+  const { render } = adze({ useEmoji: true })
     // @ts-ignore
     .assert(x === 3)
     .log('Asserts that x is 3.');
@@ -39,7 +39,7 @@ test('log renders with emoji when assertion is false (fails)', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c 📌 Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], '❌ Assertion failed:');
     t.is(args[3], 'Asserts that x is 3.');
   } else {
@@ -57,7 +57,7 @@ test('log renders when expression is true (passes)', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], 'Expression Passed:');
     t.is(args[3], 'Value of x is 2.');
   } else {
@@ -67,7 +67,7 @@ test('log renders when expression is true (passes)', (t) => {
 
 test('log renders with emoji when expression is true (passes)', (t) => {
   const x = 2;
-  const { render } = adze({ use_emoji: true })
+  const { render } = adze({ useEmoji: true })
     .test(x === 2)
     .log('Value of x is 2.');
 
@@ -75,7 +75,7 @@ test('log renders with emoji when expression is true (passes)', (t) => {
     const [method, args] = render;
     t.is(method, 'log');
     t.is(args[0], ' %c 📌 Log(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.log.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.log.style}`);
     t.is(args[2], '✅ Expression Passed:');
     t.is(args[3], 'Value of x is 2.');
   } else {

--- a/test/browser/modifiers/grouping.ts
+++ b/test/browser/modifiers/grouping.ts
@@ -15,7 +15,7 @@ test('group log renders correctly', (t) => {
     t.is(method, 'group');
     t.is(log.data.level, 5);
     t.is(args[0], ' %c Success(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.success.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.success.style}`);
     t.is(args[2], 'Opening a log group.');
   } else {
     t.fail();
@@ -31,7 +31,7 @@ test('group collapsed renders correctly', (t) => {
     t.is(method, 'groupCollapsed');
     t.is(log.data.level, 5);
     t.is(args[0], ' %c Success(1)');
-    t.is(args[1], `${defaults.base_style}${defaults.log_levels.success.style}`);
+    t.is(args[1], `${defaults.baseStyle}${defaults.logLevels.success.style}`);
     t.is(args[2], 'Opening a collapsed log group.');
   } else {
     t.fail();

--- a/test/browser/modifiers/timing.ts
+++ b/test/browser/modifiers/timing.ts
@@ -30,7 +30,7 @@ test('timer starts and ends and prints correctly', (t) => {
 });
 
 test('timer starts and ends and prints correctly with emoji', (t) => {
-  const log = adze({ use_emoji: true }).seal();
+  const log = adze({ useEmoji: true }).seal();
   log().label('test').time.log('Starting the timer.');
   const { render } = log().label('test').timeEnd.log('Stopping the timer.');
   if (render) {

--- a/test/bundle.ts
+++ b/test/bundle.ts
@@ -4,7 +4,7 @@ import { adze, bundle, createShed, removeShed } from '../src';
 global.ADZE_ENV = 'dev';
 
 test('bundles logs', (t) => {
-  const bundled = bundle(adze({ use_emoji: true }));
+  const bundled = bundle(adze({ useEmoji: true }));
 
   const { log, render } = bundled().ns('SPACE').error('This is an error!');
   const { log: log2, render: render2 } = bundled()
@@ -24,9 +24,7 @@ test('bundles logs', (t) => {
 
 test('can bundle sealed log instance', (t) => {
   createShed();
-  const bundled = bundle(
-    adze({ use_emoji: true }).count.label('SEALED').seal()
-  );
+  const bundled = bundle(adze({ useEmoji: true }).count.label('SEALED').seal());
 
   const { log } = bundled().ns('SPACE').error('This is an error!');
   const { log: log2 } = bundled()

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -11,7 +11,7 @@ import {
 global.ADZE_ENV = 'dev';
 
 test('filters a log collection by namespace', (t) => {
-  const bundled = bundle(adze({ use_emoji: true }));
+  const bundled = bundle(adze({ useEmoji: true }));
 
   bundled().ns('SPACE').error('This is an error!');
   bundled().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
@@ -27,7 +27,7 @@ test('filters a log collection by namespace', (t) => {
 });
 
 test('filters a log collection by label', (t) => {
-  const bundled = bundle(adze({ use_emoji: true }));
+  const bundled = bundle(adze({ useEmoji: true }));
 
   bundled().ns('SPACE').error('This is an error!');
   bundled().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
@@ -43,7 +43,7 @@ test('filters a log collection by label', (t) => {
 });
 
 test('filters a log collection by levels', (t) => {
-  const bundled = bundle(adze({ use_emoji: true }));
+  const bundled = bundle(adze({ useEmoji: true }));
 
   bundled().ns('SPACE').error('This is an error!');
   bundled().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
@@ -59,7 +59,7 @@ test('filters a log collection by levels', (t) => {
 });
 
 test('filterCollection filters collection by a log data value', (t) => {
-  const bundled = bundle(adze({ use_emoji: true }));
+  const bundled = bundle(adze({ useEmoji: true }));
 
   bundled().ns('SPACE').silent.error('This is an error!');
   bundled().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');

--- a/test/node/customize.ts
+++ b/test/node/customize.ts
@@ -58,3 +58,23 @@ test('renders a custom log with emoji', (t) => {
     t.fail();
   }
 });
+
+// =========================
+// UNSTYLED FOR STDOUT
+// =========================
+
+test('renders an unstyled log', (t) => {
+  const unstyled = adze({ unstyled: true })
+    .label('unstyled')
+    .log('This log should have no style.');
+
+  t.truthy(unstyled.log);
+
+  if (unstyled.render) {
+    const [method, args] = unstyled.render;
+    t.is(method, 'log');
+    t.is(args[0], ' Log(1)        ');
+    t.is(args[1], '[unstyled] ');
+    t.is(args[2], 'This log should have no style.');
+  }
+});

--- a/test/node/customize.ts
+++ b/test/node/customize.ts
@@ -9,7 +9,7 @@ test('renders a custom log', (t) => {
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const terminal: ChalkStyle[] = ['bgCyanBright', 'cyan'];
   const { log, render } = adze({
-    custom_levels: {
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',
@@ -36,8 +36,8 @@ test('renders a custom log with emoji', (t) => {
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const terminal: ChalkStyle[] = ['bgCyanBright', 'cyan'];
   const { log, render } = adze({
-    use_emoji: true,
-    custom_levels: {
+    useEmoji: true,
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',

--- a/test/node/defaults-emoji.ts
+++ b/test/node/defaults-emoji.ts
@@ -9,7 +9,7 @@ global.ADZE_ENV = 'dev';
 // =========================
 
 test('renders a default alert log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).alert('testing');
+  const t_log = adze({ useEmoji: true }).alert('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -17,7 +17,7 @@ test('renders a default alert log with emoji', (t) => {
     t.is(method, 'error');
     t.is(
       args[0],
-      applyChalkStyles(' 🚨 Alert(1)      ', defaults.log_levels.alert.terminal)
+      applyChalkStyles(' 🚨 Alert(1)      ', defaults.logLevels.alert.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -26,7 +26,7 @@ test('renders a default alert log with emoji', (t) => {
 });
 
 test('renders a default error log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).error('testing');
+  const t_log = adze({ useEmoji: true }).error('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -34,7 +34,7 @@ test('renders a default error log with emoji', (t) => {
     t.is(method, 'error');
     t.is(
       args[0],
-      applyChalkStyles(' 🔥 Error(1)      ', defaults.log_levels.error.terminal)
+      applyChalkStyles(' 🔥 Error(1)      ', defaults.logLevels.error.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -43,7 +43,7 @@ test('renders a default error log with emoji', (t) => {
 });
 
 test('renders a default warn log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).warn('testing');
+  const t_log = adze({ useEmoji: true }).warn('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -51,7 +51,7 @@ test('renders a default warn log with emoji', (t) => {
     t.is(method, 'warn');
     t.is(
       args[0],
-      applyChalkStyles(' 🔔 Warn(1)       ', defaults.log_levels.warn.terminal)
+      applyChalkStyles(' 🔔 Warn(1)       ', defaults.logLevels.warn.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -60,7 +60,7 @@ test('renders a default warn log with emoji', (t) => {
 });
 
 test('renders a default info log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).info('testing');
+  const t_log = adze({ useEmoji: true }).info('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -68,7 +68,7 @@ test('renders a default info log with emoji', (t) => {
     t.is(method, 'info');
     t.is(
       args[0],
-      applyChalkStyles(' 📬 Info(1)       ', defaults.log_levels.info.terminal)
+      applyChalkStyles(' 📬 Info(1)       ', defaults.logLevels.info.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -77,7 +77,7 @@ test('renders a default info log with emoji', (t) => {
 });
 
 test('renders a default fail log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).fail('testing');
+  const t_log = adze({ useEmoji: true }).fail('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -85,7 +85,7 @@ test('renders a default fail log with emoji', (t) => {
     t.is(method, 'info');
     t.is(
       args[0],
-      applyChalkStyles(' ❌ Fail(1)       ', defaults.log_levels.fail.terminal)
+      applyChalkStyles(' ❌ Fail(1)       ', defaults.logLevels.fail.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -94,7 +94,7 @@ test('renders a default fail log with emoji', (t) => {
 });
 
 test('renders a default success log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).success('testing');
+  const t_log = adze({ useEmoji: true }).success('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -104,7 +104,7 @@ test('renders a default success log with emoji', (t) => {
       args[0],
       applyChalkStyles(
         ' 🎉 Success(1)    ',
-        defaults.log_levels.success.terminal
+        defaults.logLevels.success.terminal
       )
     );
     t.is(args[1], 'testing');
@@ -114,7 +114,7 @@ test('renders a default success log with emoji', (t) => {
 });
 
 test('renders a default log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).log('testing');
+  const t_log = adze({ useEmoji: true }).log('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -122,7 +122,7 @@ test('renders a default log with emoji', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' 📌 Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' 📌 Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -131,7 +131,7 @@ test('renders a default log with emoji', (t) => {
 });
 
 test('renders a default debug log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).debug('testing');
+  const t_log = adze({ useEmoji: true }).debug('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -139,7 +139,7 @@ test('renders a default debug log with emoji', (t) => {
     t.is(method, 'debug');
     t.is(
       args[0],
-      applyChalkStyles(' 🐞 Debug(1)      ', defaults.log_levels.debug.terminal)
+      applyChalkStyles(' 🐞 Debug(1)      ', defaults.logLevels.debug.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -148,7 +148,7 @@ test('renders a default debug log with emoji', (t) => {
 });
 
 test('renders a default verbose log with emoji', (t) => {
-  const t_log = adze({ use_emoji: true }).verbose('testing');
+  const t_log = adze({ useEmoji: true }).verbose('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {
@@ -158,7 +158,7 @@ test('renders a default verbose log with emoji', (t) => {
       args[0],
       applyChalkStyles(
         ' 💤 Verbose(1)    ',
-        defaults.log_levels.verbose.terminal
+        defaults.logLevels.verbose.terminal
       )
     );
     t.is(args[1], 'testing');

--- a/test/node/defaults.ts
+++ b/test/node/defaults.ts
@@ -15,7 +15,7 @@ test('renders a default alert log', (t) => {
     t.is(method, 'error');
     t.is(
       args[0],
-      applyChalkStyles(' Alert(1)      ', defaults.log_levels.alert.terminal)
+      applyChalkStyles(' Alert(1)      ', defaults.logLevels.alert.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -32,7 +32,7 @@ test('renders a default error log', (t) => {
     t.is(method, 'error');
     t.is(
       args[0],
-      applyChalkStyles(' Error(1)      ', defaults.log_levels.error.terminal)
+      applyChalkStyles(' Error(1)      ', defaults.logLevels.error.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -49,7 +49,7 @@ test('renders a default warn log', (t) => {
     t.is(method, 'warn');
     t.is(
       args[0],
-      applyChalkStyles(' Warn(1)       ', defaults.log_levels.warn.terminal)
+      applyChalkStyles(' Warn(1)       ', defaults.logLevels.warn.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -66,7 +66,7 @@ test('renders a default info log', (t) => {
     t.is(method, 'info');
     t.is(
       args[0],
-      applyChalkStyles(' Info(1)       ', defaults.log_levels.info.terminal)
+      applyChalkStyles(' Info(1)       ', defaults.logLevels.info.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -83,7 +83,7 @@ test('renders a default fail log', (t) => {
     t.is(method, 'info');
     t.is(
       args[0],
-      applyChalkStyles(' Fail(1)       ', defaults.log_levels.fail.terminal)
+      applyChalkStyles(' Fail(1)       ', defaults.logLevels.fail.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -100,7 +100,7 @@ test('renders a default success log', (t) => {
     t.is(method, 'info');
     t.is(
       args[0],
-      applyChalkStyles(' Success(1)    ', defaults.log_levels.success.terminal)
+      applyChalkStyles(' Success(1)    ', defaults.logLevels.success.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -117,7 +117,7 @@ test('renders a default log', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -134,7 +134,7 @@ test('renders a default debug log', (t) => {
     t.is(method, 'debug');
     t.is(
       args[0],
-      applyChalkStyles(' Debug(1)      ', defaults.log_levels.debug.terminal)
+      applyChalkStyles(' Debug(1)      ', defaults.logLevels.debug.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -151,7 +151,7 @@ test('renders a default verbose log', (t) => {
     t.is(method, 'debug');
     t.is(
       args[0],
-      applyChalkStyles(' Verbose(1)    ', defaults.log_levels.verbose.terminal)
+      applyChalkStyles(' Verbose(1)    ', defaults.logLevels.verbose.terminal)
     );
     t.is(args[1], 'testing');
   } else {
@@ -164,7 +164,7 @@ test('renders a custom log', (t) => {
     'padding-right: 26px; border-color: 1px solid red; color: white; border-color: blue;';
   const terminal: ChalkStyle[] = ['bgCyanBright', 'cyan'];
   const { log, render } = adze({
-    custom_levels: {
+    customLevels: {
       custom: {
         level: 1,
         emoji: '🤪',
@@ -187,7 +187,7 @@ test('renders a custom log', (t) => {
 });
 
 test('terminal styles color fidelity is customizable', (t) => {
-  const t_log = adze({ terminal_color_fidelity: 0 }).log('testing');
+  const t_log = adze({ terminalColorFidelity: 0 }).log('testing');
   t.truthy(t_log.log);
 
   if (t_log.render) {

--- a/test/node/modifiers/conditional.ts
+++ b/test/node/modifiers/conditional.ts
@@ -16,7 +16,7 @@ test('log renders when assertion is false (fails)', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], 'Assertion failed:');
     t.is(args[2], 'Asserts that x is 3.');
@@ -27,7 +27,7 @@ test('log renders when assertion is false (fails)', (t) => {
 
 test('log renders with emoji when assertion is false (fails)', (t) => {
   const x = 2;
-  const { render } = adze({ use_emoji: true })
+  const { render } = adze({ useEmoji: true })
     // @ts-expect-error This method is attempting to assert that x is equal to 3 even though TS catches it.
     .assert(x === 3)
     .log('Asserts that x is 3.');
@@ -37,7 +37,7 @@ test('log renders with emoji when assertion is false (fails)', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' 📌 Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' 📌 Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], '❌ Assertion failed:');
     t.is(args[2], 'Asserts that x is 3.');
@@ -57,7 +57,7 @@ test('log renders when expression is true (passes)', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], 'Expression Passed:');
     t.is(args[2], 'Value of x is 2.');
@@ -68,7 +68,7 @@ test('log renders when expression is true (passes)', (t) => {
 
 test('log renders with emoji when expression is true (passes)', (t) => {
   const x = 2;
-  const { render } = adze({ use_emoji: true })
+  const { render } = adze({ useEmoji: true })
     .test(x === 2)
     .log('Value of x is 2.');
 
@@ -77,7 +77,7 @@ test('log renders with emoji when expression is true (passes)', (t) => {
     t.is(method, 'log');
     t.is(
       args[0],
-      applyChalkStyles(' 📌 Log(1)        ', defaults.log_levels.log.terminal)
+      applyChalkStyles(' 📌 Log(1)        ', defaults.logLevels.log.terminal)
     );
     t.is(args[1], '✅ Expression Passed:');
     t.is(args[2], 'Value of x is 2.');

--- a/test/node/modifiers/grouping.ts
+++ b/test/node/modifiers/grouping.ts
@@ -12,7 +12,7 @@ test('group log renders correctly', (t) => {
     t.is(log.data.level, 5);
     t.is(
       args[0],
-      applyChalkStyles(' Success(1)    ', defaults.log_levels.success.terminal)
+      applyChalkStyles(' Success(1)    ', defaults.logLevels.success.terminal)
     );
     t.is(args[1], 'Opening a log group.');
   } else {
@@ -30,7 +30,7 @@ test('group collapsed renders correctly', (t) => {
     t.is(log.data.level, 5);
     t.is(
       args[0],
-      applyChalkStyles(' Success(1)    ', defaults.log_levels.success.terminal)
+      applyChalkStyles(' Success(1)    ', defaults.logLevels.success.terminal)
     );
     t.is(args[1], 'Opening a collapsed log group.');
   } else {

--- a/test/node/modifiers/timing.ts
+++ b/test/node/modifiers/timing.ts
@@ -25,7 +25,7 @@ test('timer starts and ends and prints correctly', (t) => {
 });
 
 test('timer starts and ends and prints correctly with emoji', (t) => {
-  const log = adze({ use_emoji: true }).seal();
+  const log = adze({ useEmoji: true }).seal();
   log().label('test').time.log('Starting the timer.');
   const { render } = log().label('test').timeEnd.log('Stopping the timer.');
   if (render) {

--- a/test/shed.ts
+++ b/test/shed.ts
@@ -41,7 +41,7 @@ test('shedExists correctly indicates that a shed instance exists in the global c
 
 test('stores a log instance', (t) => {
   // We have a log instance before a shed existed
-  const { log } = adze({ use_emoji: true })
+  const { log } = adze({ useEmoji: true })
     .ns('Foo')
     .info('This is an info log.');
   // Create a shed
@@ -71,15 +71,15 @@ test('store returns the cache limit from getter', (t) => {
 
 test('store accepts global config overrides with setter', (t) => {
   const shed = createShed();
-  shed.config = { cache_limit: 50 };
+  shed.config = { cacheLimit: 50 };
 
   t.is(shed.cacheLimit, 50);
 });
 
 test('store returns global config overrides from getter', (t) => {
   const shed = createShed({
-    global_cfg: {
-      log_levels: {
+    globalCfg: {
+      logLevels: {
         log: {
           level: 100,
         },
@@ -87,13 +87,13 @@ test('store returns global config overrides from getter', (t) => {
     },
   });
   const cfg = shed.overrides;
-  t.is(cfg?.log_levels?.log?.level, 100);
+  t.is(cfg?.logLevels?.log?.level, 100);
 });
 
 test('store hasOverrides correctly indicates that global config override has been set', (t) => {
   const shed = createShed({
-    global_cfg: {
-      log_levels: {
+    globalCfg: {
+      logLevels: {
         log: {
           level: 100,
         },
@@ -205,7 +205,7 @@ test('fires the log listeners', (t) => {
 });
 
 test('configured cache limit works properly', (t) => {
-  const shed = createShed({ cache_limit: 2 });
+  const shed = createShed({ cacheLimit: 2 });
 
   adze().log('Log 1');
   adze().log('Log 2');


### PR DESCRIPTION
- Updates adze configuration props to all be camelCase for consistency.
- Adds new configuration option to disable styling on log render to support stdout and avoid styling artifacts.
- Adds documentation for the new `unstyled` configuration property.