### PR TITLE
fix(namespace): global config namespace include now properly hides logs with no namespace

### DIFF
--- a/demo_funcs.js
+++ b/demo_funcs.js
@@ -24,6 +24,10 @@ export default function runDemo(lib, el) {
   withTrace(lib);
   unstyled(lib);
   withTimestamp(lib);
+  namespaceIncludeFilter(lib);
+  namespaceExcludeFilter(lib);
+  labelIncludeFilter(lib);
+  labelExcludeFilter(lib);
 }
 
 function screenshots({ adze, createShed }, el) {
@@ -396,4 +400,70 @@ function withTimestamp({ adze }) {
   console.log('\n----- With Timestamp -----\n');
   adze().label('timestamped').timestamp.log("I have a timestamp.");
   adze({ unstyled: true }).label('timestamped').timestamp.log("I have a timestamp and no styles.");
+}
+
+function namespaceIncludeFilter({ adze }) {
+  console.log('\n----- Global Namespace Include Filter -----\n');
+  const logger = adze({
+    useEmoji: true,
+    filters: {
+      namespace: {
+        include: ['foo'],
+      },
+    },
+  }).seal();
+
+  logger().ns('foo').success("I should print.");
+  logger().ns('bar').fail("I should not print.");
+  logger().ns(['foo', 'bar']).success("I should print.");
+  logger().fail("I should not print.");
+}
+
+function namespaceExcludeFilter({ adze }) {
+  console.log('\n----- Global Namespace Exclude Filter -----\n');
+  const logger = adze({
+    useEmoji: true,
+    filters: {
+      namespace: {
+        exclude: ['foo'],
+      },
+    },
+  }).seal();
+
+  logger().ns('foo').fail("I should not print.");
+  logger().ns('bar').success("I should print.");
+  logger().ns(['foo', 'bar']).fail("I should not print.");
+  logger().success("I should print.");
+}
+
+function labelIncludeFilter({ adze }) {
+  console.log('\n----- Global Label Include Filter -----\n');
+  const logger = adze({
+    useEmoji: true,
+    filters: {
+      label: {
+        include: ['foo'],
+      },
+    },
+  }).seal();
+
+  logger().label('foo').success("I should print.");
+  logger().label('bar').fail("I should not print.");
+  logger().fail("I should not print.");
+}
+
+function labelExcludeFilter({ adze }) {
+  console.log('\n----- Global Label Exclude Filter -----\n');
+  const logger = adze({
+    useEmoji: true,
+    filters: {
+      label: {
+        exclude: ['foo'],
+      },
+    },
+  }).seal();
+
+  logger().label('foo').fail("I should not print.");
+  logger().label('bar').success("I should print.");
+  logger().success("I should not print.");
 }

--- a/src/conditions/filters.ts
+++ b/src/conditions/filters.ts
@@ -50,6 +50,10 @@ export function levelAllowed(data: FinalLogData): boolean {
  */
 export function labelAllowed(data: FinalLogData): boolean {
   return filterAllowed(data.cfg, 'label', (filter, func) => {
+    if (filter === 'include' && data.label.name === null) {
+      // Do not include logs that do not have a label
+      return false;
+    }
     const source = data.cfg.filters?.label?.[filter] ?? ([] as string[]);
     return func<string>(source, data.label.name ?? '');
   });
@@ -69,12 +73,16 @@ export function namespaceAllowed(data: FinalLogData): boolean {
       // Namespace log value is an array. Check each namespace value.
       const arr = log_ns.map((val) => func<string>(filter_ns, val));
 
-      // If filter is include, namspace is allowed if at least one passes
+      // If filter is include, namespace is allowed if at least one passes and the log has
+      // at least one namespace. Logs without namespaces are thrown out.
       if (filter === 'include') {
         return arr.includes(true);
       }
       // If filter is exclude, namspace is allowed if all pass
       return !arr.includes(false);
+    } else if (filter === 'include') {
+      // If the log has no namespaces defined and the filter is include we should hide the log.
+      return false;
     }
   });
 }

--- a/test/adze.ts
+++ b/test/adze.ts
@@ -227,13 +227,13 @@ test('global filter includes logs based on namespace', (t) => {
   const { render: d_render } = log().ns('test2').debug('This is a debug!');
   const { render: v_render } = log().verbose('This is a verbose!');
 
-  t.truthy(a_render);
+  t.falsy(a_render);
   t.truthy(e_render);
-  t.truthy(w_render);
+  t.falsy(w_render);
   t.truthy(i_render);
-  t.truthy(f_render);
-  t.truthy(s_render);
+  t.falsy(f_render);
+  t.falsy(s_render);
   t.truthy(l_render);
   t.falsy(d_render);
-  t.truthy(v_render);
+  t.falsy(v_render);
 });

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -75,3 +75,103 @@ test('filterCollection filters collection by a log data value', (t) => {
   );
   t.is(filtered.length, 3);
 });
+
+// test('config filtering by namespace include only prints logs with specified namespace', (t) => {
+//   const logger = adze({
+//     filters: {
+//       namespace: {
+//         include: ['foo'],
+//       },
+//     },
+//   }).seal();
+
+//   const { render: render1 } = logger().ns('foo').log('I should print.');
+//   const { render: render2 } = logger().ns('bar').log('I should not print.');
+//   const { render: render3 } = logger()
+//     .ns(['foo', 'bar'])
+//     .log('I should print.');
+//   const { render: render4 } = logger().log('I should not print.');
+
+//   t.truthy(render1);
+//   t.falsy(render2);
+//   t.truthy(render3);
+//   t.falsy(render4);
+// });
+
+// test('config filtering by namespace exclude prints all logs without the specified namespace', (t) => {
+//   const logger = adze({
+//     filters: {
+//       namespace: {
+//         exclude: ['foo'],
+//       },
+//     },
+//   }).seal();
+
+//   const { render: render1 } = logger().ns('foo').log('I should not print.');
+//   const { render: render2 } = logger().ns('bar').log('I should print.');
+//   const { render: render3 } = logger()
+//     .ns(['foo', 'bar'])
+//     .log('I should not print.');
+//   const { render: render4 } = logger().log('I should print.');
+
+//   t.falsy(render1);
+//   t.truthy(render2);
+//   t.falsy(render3);
+//   t.truthy(render4);
+// });
+
+// test('config filtering by label include only prints logs with specified label', (t) => {
+//   const logger = adze({
+//     filters: {
+//       label: {
+//         include: ['foo'],
+//       },
+//     },
+//   }).seal();
+
+//   const { render: render1 } = logger().label('foo').log('I should print.');
+//   const { render: render2 } = logger().label('bar').log('I should not print.');
+//   const { render: render3 } = logger().log('I should not print.');
+
+//   t.truthy(render1);
+//   t.falsy(render2);
+//   t.falsy(render3);
+// });
+
+// test('config filtering by label exclude prints all logs without the specified label', (t) => {
+//   const logger = adze({
+//     filters: {
+//       label: {
+//         exclude: ['foo'],
+//       },
+//     },
+//   }).seal();
+
+//   const { render: render1 } = logger().label('foo').log('I should not print.');
+//   const { render: render2 } = logger().label('bar').log('I should print.');
+//   const { render: render3 } = logger().log('I should print.');
+
+//   t.falsy(render1);
+//   t.truthy(render2);
+//   t.truthy(render3);
+// });
+
+// test('config filtering hideAll should force all logs to not print', (t) => {
+//   const logger = adze({
+//     filters: {
+//       hideAll: true,
+//     },
+//   }).seal();
+
+//   const { render: render1 } = logger().label('foo').log('I should not print.');
+//   const { render: render2 } = logger()
+//     .label('bar')
+//     .debug('I should not print.');
+//   const { render: render3 } = logger()
+//     .ns(['foo', 'bar'])
+//     .alert('I should not print.');
+
+//   t.falsy(render1);
+//   t.falsy(render2);
+//   t.falsy(render3);
+// });


### PR DESCRIPTION
Previously, logs without a namespace were not hidden when a global filter of include for a namespace
was set. This meant that if you only wanted to include logs with a namespace of 'foo' in the output,
you would still see all logs that did not specify a namespace.