### PR TITLE
feat(meta-modifier): Meta modifier interface update

### DIFF
--- a/docs/guide/modifiers.md
+++ b/docs/guide/modifiers.md
@@ -442,8 +442,12 @@ _This is not a standard API._
 
 ### Interface
 
+> The interface of `meta<KV extends [string, any]>(...[key, val]: KV): this;` is available for Adze versions >= 1.2.0
+
 ```typescript
 class BaseLog {
+  // Types are Overloaded
+  public meta<T>(key: string, val: T): this;
   public meta<KV extends [string, any]>(...[key, val]: KV): this;
 }
 ```

--- a/docs/guide/modifiers.md
+++ b/docs/guide/modifiers.md
@@ -444,13 +444,30 @@ _This is not a standard API._
 
 ```typescript
 class BaseLog {
-  public meta<T>(key: string, value: T): this;
+  public meta<KV extends [string, any]>(...[key, val]: KV): this;
 }
 ```
 
 ### Example
 
 ```javascript
+import { adze, createShed } from 'adze';
+
+// Let's optionally create a shed to show the use of meta data on listeners
+const shed = createShed();
+
+// We'll listen only to logs of level 6 which is "log"
+shed.addListener([6], (data) => {
+  adze().info("My log's meta data!", data.meta);
+});
+
+// Let's create a super important message to attach as meta data
+const info = 'Hello World!';
+
+adze().meta('message', info).log('This log contains an important message.');
+```
+
+```typescript
 import { adze, createShed } from 'adze';
 
 // Let's optionally create a shed to show the use of meta data on listeners

--- a/src/log/BaseLog.ts
+++ b/src/log/BaseLog.ts
@@ -479,7 +479,9 @@ export class BaseLog {
    *
    * This is a non-standard API.
    */
-  public meta<T>(key: string, val: T): this {
+  public meta<T>(key: string, val: T): this;
+  public meta<KV extends [string, any]>(...[key, val]: KV): this;
+  public meta(key: string, val: unknown): this {
     return this.modifier((ctxt) => {
       ctxt.metaData[key] = val;
     });

--- a/test/meta.ts
+++ b/test/meta.ts
@@ -3,14 +3,33 @@ import { adze } from '../src';
 
 global.ADZE_ENV = 'dev';
 
-interface Test {
+interface TestMeta {
   a: number;
   b: number;
 }
+type Test = ['test', TestMeta];
 
-test('log saves meta data correctly', (t) => {
+test('log saves meta data correctly with Tuple generic type', (t) => {
   const with_meta = adze()
     .meta<Test>('test', { a: 12, b: 34 })
+    .seal();
+  const { log, render } = with_meta()
+    .meta('test2', 5678)
+    .log('Added meta twice.');
+
+  t.truthy(render);
+  t.deepEqual(log.data.meta, {
+    test: {
+      a: 12,
+      b: 34,
+    },
+    test2: 5678,
+  });
+});
+
+test('log saves meta data correctly with generic type', (t) => {
+  const with_meta = adze()
+    .meta<TestMeta>('test', { a: 12, b: 34 })
     .seal();
   const { log, render } = with_meta()
     .meta('test2', 5678)


### PR DESCRIPTION
Adds an overloaded interface for the meta modifier to allow for generic tuple types that can validate the types of both the key and the value passed into the meta modifier.