### PR TITLE
feat: logs now always render and printed boolean now returned when terminated

### DIFF
--- a/src/_contracts/Log.ts
+++ b/src/_contracts/Log.ts
@@ -74,6 +74,7 @@ export interface LogData {
   dumpContext: boolean;
   expression?: boolean;
   isSilent: boolean;
+  printed: boolean;
   label: LabelData;
   level: number | null;
   meta: MetaData;
@@ -104,4 +105,5 @@ export interface FinalLogData extends LogData {
 export interface TerminatedLog<I extends BaseLog> {
   log: I;
   render: LogRender | null;
+  printed: boolean;
 }

--- a/src/_contracts/Shed.ts
+++ b/src/_contracts/Shed.ts
@@ -12,7 +12,8 @@ export type ListenerBucket = Map<number, ListenerCallback>;
 
 export type ListenerCallback = (
   LogData: LogData | FinalLogData,
-  render: LogRender | null
+  render: LogRender | null,
+  printed: boolean
 ) => void;
 
 export interface ShedConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-export { adze } from './adze';
+import { adze } from './adze';
+export { adze };
+export default adze;
 export { Label } from './label';
 export { defaults } from './_defaults';
 export {

--- a/src/shed/Shed.ts
+++ b/src/shed/Shed.ts
@@ -204,9 +204,13 @@ export class Shed {
    * Fires any listeners that are watching the log level defined in the provided log data. The log data
    * and render object will be passed to the listener callback.
    */
-  public fireListeners(log: FinalLogData, render: LogRender | null): void {
+  public fireListeners(
+    log: FinalLogData,
+    render: LogRender | null,
+    printed: boolean
+  ): void {
     this.listeners.get(log.level)?.forEach((listener) => {
-      listener(log, render);
+      listener(log, render, printed);
     });
   }
 

--- a/test/adze.ts
+++ b/test/adze.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import { passesFilters } from '../src/conditions';
-import { adze, defaults, isFinalLogData } from '../src';
+import adze, { defaults, isFinalLogData } from '../src';
 import { Defaults, LogLevelDefinition } from '../src/_contracts';
 
 global.ADZE_ENV = 'dev';
@@ -43,21 +43,23 @@ test('create a new logger with defaults', (t) => {
   t.is(cfg.filters.hideAll, defaults.filters.hideAll);
 });
 
-test('prevents log render when the log level is lowered', (t) => {
+test('prevents log from printing when the log level is lowered', (t) => {
   const terminated = adze({ logLevel: 5 }).log('testing');
   t.truthy(terminated.log);
-  t.is(terminated.render, null);
+  t.truthy(terminated.render);
+  t.falsy(terminated.printed);
 });
 
-test('prevents log render when in a test environment', (t) => {
+test('prevents log from printing when in a test environment', (t) => {
   global.ADZE_ENV = 'test';
   const terminated = adze().log('testing');
   t.truthy(terminated.log);
-  t.is(terminated.render, null);
+  t.truthy(terminated.render);
+  t.falsy(terminated.printed);
   global.ADZE_ENV = 'dev';
 });
 
-test('passesFilters correctly indicates that a log is allowed to render', (t) => {
+test('passesFilters correctly indicates that a log is allowed to print', (t) => {
   const { log } = adze({
     filters: {
       hideAll: true,
@@ -76,7 +78,7 @@ test('passesFilters correctly indicates that a log is allowed to render', (t) =>
   }
 });
 
-test('hideAll global log filter prevents all logs rendering', (t) => {
+test('hideAll global log filter prevents all logs printing', (t) => {
   const cfg = {
     filters: {
       hideAll: true,
@@ -85,25 +87,25 @@ test('hideAll global log filter prevents all logs rendering', (t) => {
 
   const log = adze(cfg).seal();
 
-  const { render: a_render } = log().alert('This is an alert!');
-  const { render: e_render } = log().error('This is an error!');
-  const { render: w_render } = log().warn('This is a warn!');
-  const { render: i_render } = log().info('This is an info!');
-  const { render: f_render } = log().fail('This is a failure!');
-  const { render: s_render } = log().success('This is a success!');
-  const { render: l_render } = log().log('This is a log!');
-  const { render: d_render } = log().debug('This is a debug!');
-  const { render: v_render } = log().verbose('This is a verbose!');
+  const { printed: a_printed } = log().alert('This is an alert!');
+  const { printed: e_printed } = log().error('This is an error!');
+  const { printed: w_printed } = log().warn('This is a warn!');
+  const { printed: i_printed } = log().info('This is an info!');
+  const { printed: f_printed } = log().fail('This is a failure!');
+  const { printed: s_printed } = log().success('This is a success!');
+  const { printed: l_printed } = log().log('This is a log!');
+  const { printed: d_printed } = log().debug('This is a debug!');
+  const { printed: v_printed } = log().verbose('This is a verbose!');
 
-  t.falsy(a_render);
-  t.falsy(e_render);
-  t.falsy(w_render);
-  t.falsy(i_render);
-  t.falsy(f_render);
-  t.falsy(s_render);
-  t.falsy(l_render);
-  t.falsy(d_render);
-  t.falsy(v_render);
+  t.falsy(a_printed);
+  t.falsy(e_printed);
+  t.falsy(w_printed);
+  t.falsy(i_printed);
+  t.falsy(f_printed);
+  t.falsy(s_printed);
+  t.falsy(l_printed);
+  t.falsy(d_printed);
+  t.falsy(v_printed);
 });
 
 test('global filter excludes logs based on label', (t) => {
@@ -117,25 +119,25 @@ test('global filter excludes logs based on label', (t) => {
 
   const log = adze(cfg).seal();
 
-  const { render: a_render } = log().alert('This is an alert!');
-  const { render: e_render } = log().label('test').error('This is an error!');
-  const { render: w_render } = log().warn('This is a warn!');
-  const { render: i_render } = log().label('test').info('This is an info!');
-  const { render: f_render } = log().fail('This is a failure!');
-  const { render: s_render } = log().success('This is a success!');
-  const { render: l_render } = log().label('test2').log('This is a log!');
-  const { render: d_render } = log().label('test2').debug('This is a debug!');
-  const { render: v_render } = log().verbose('This is a verbose!');
+  const { printed: a_printed } = log().alert('This is an alert!');
+  const { printed: e_printed } = log().label('test').error('This is an error!');
+  const { printed: w_printed } = log().warn('This is a warn!');
+  const { printed: i_printed } = log().label('test').info('This is an info!');
+  const { printed: f_printed } = log().fail('This is a failure!');
+  const { printed: s_printed } = log().success('This is a success!');
+  const { printed: l_printed } = log().label('test2').log('This is a log!');
+  const { printed: d_printed } = log().label('test2').debug('This is a debug!');
+  const { printed: v_printed } = log().verbose('This is a verbose!');
 
-  t.truthy(a_render);
-  t.falsy(e_render);
-  t.truthy(w_render);
-  t.falsy(i_render);
-  t.truthy(f_render);
-  t.truthy(s_render);
-  t.falsy(l_render);
-  t.falsy(d_render);
-  t.truthy(v_render);
+  t.truthy(a_printed);
+  t.falsy(e_printed);
+  t.truthy(w_printed);
+  t.falsy(i_printed);
+  t.truthy(f_printed);
+  t.truthy(s_printed);
+  t.falsy(l_printed);
+  t.falsy(d_printed);
+  t.truthy(v_printed);
 });
 
 test('global filter includes logs based on label', (t) => {
@@ -149,25 +151,25 @@ test('global filter includes logs based on label', (t) => {
 
   const log = adze(cfg).seal();
 
-  const { render: a_render } = log().alert('This is an alert!');
-  const { render: e_render } = log().label('test').error('This is an error!');
-  const { render: w_render } = log().warn('This is a warn!');
-  const { render: i_render } = log().label('test').info('This is an info!');
-  const { render: f_render } = log().fail('This is a failure!');
-  const { render: s_render } = log().success('This is a success!');
-  const { render: l_render } = log().label('test2').log('This is a log!');
-  const { render: d_render } = log().label('test2').debug('This is a debug!');
-  const { render: v_render } = log().verbose('This is a verbose!');
+  const { printed: a_printed } = log().alert('This is an alert!');
+  const { printed: e_printed } = log().label('test').error('This is an error!');
+  const { printed: w_printed } = log().warn('This is a warn!');
+  const { printed: i_printed } = log().label('test').info('This is an info!');
+  const { printed: f_printed } = log().fail('This is a failure!');
+  const { printed: s_printed } = log().success('This is a success!');
+  const { printed: l_printed } = log().label('test2').log('This is a log!');
+  const { printed: d_printed } = log().label('test2').debug('This is a debug!');
+  const { printed: v_printed } = log().verbose('This is a verbose!');
 
-  t.falsy(a_render);
-  t.truthy(e_render);
-  t.falsy(w_render);
-  t.truthy(i_render);
-  t.falsy(f_render);
-  t.falsy(s_render);
-  t.truthy(l_render);
-  t.truthy(d_render);
-  t.falsy(v_render);
+  t.falsy(a_printed);
+  t.truthy(e_printed);
+  t.falsy(w_printed);
+  t.truthy(i_printed);
+  t.falsy(f_printed);
+  t.falsy(s_printed);
+  t.truthy(l_printed);
+  t.truthy(d_printed);
+  t.falsy(v_printed);
 });
 
 test('global filter excludes logs based on namespace', (t) => {
@@ -181,27 +183,27 @@ test('global filter excludes logs based on namespace', (t) => {
 
   const log = adze(cfg).seal();
 
-  const { render: a_render } = log().alert('This is an alert!');
-  const { render: e_render } = log().ns('testWOW').error('This is an error!');
-  const { render: w_render } = log().warn('This is a warn!');
-  const { render: i_render } = log().ns('testWOW').info('This is an info!');
-  const { render: f_render } = log().fail('This is a failure!');
-  const { render: s_render } = log().success('This is a success!');
-  const { render: l_render } = log()
+  const { printed: a_printed } = log().alert('This is an alert!');
+  const { printed: e_printed } = log().ns('testWOW').error('This is an error!');
+  const { printed: w_printed } = log().warn('This is a warn!');
+  const { printed: i_printed } = log().ns('testWOW').info('This is an info!');
+  const { printed: f_printed } = log().fail('This is a failure!');
+  const { printed: s_printed } = log().success('This is a success!');
+  const { printed: l_printed } = log()
     .ns(['testWOW', 'test2'])
     .log('This is a log!');
-  const { render: d_render } = log().ns('test2').debug('This is a debug!');
-  const { render: v_render } = log().verbose('This is a verbose!');
+  const { printed: d_printed } = log().ns('test2').debug('This is a debug!');
+  const { printed: v_printed } = log().verbose('This is a verbose!');
 
-  t.truthy(a_render);
-  t.falsy(e_render);
-  t.truthy(w_render);
-  t.falsy(i_render);
-  t.truthy(f_render);
-  t.truthy(s_render);
-  t.falsy(l_render);
-  t.truthy(d_render);
-  t.truthy(v_render);
+  t.truthy(a_printed);
+  t.falsy(e_printed);
+  t.truthy(w_printed);
+  t.falsy(i_printed);
+  t.truthy(f_printed);
+  t.truthy(s_printed);
+  t.falsy(l_printed);
+  t.truthy(d_printed);
+  t.truthy(v_printed);
 });
 
 test('global filter includes logs based on namespace', (t) => {
@@ -215,25 +217,25 @@ test('global filter includes logs based on namespace', (t) => {
 
   const log = adze(cfg).seal();
 
-  const { render: a_render } = log().alert('This is an alert!');
-  const { render: e_render } = log().ns('test').error('This is an error!');
-  const { render: w_render } = log().warn('This is a warn!');
-  const { render: i_render } = log().ns('test').info('This is an info!');
-  const { render: f_render } = log().fail('This is a failure!');
-  const { render: s_render } = log().success('This is a success!');
-  const { render: l_render } = log()
+  const { printed: a_printed } = log().alert('This is an alert!');
+  const { printed: e_printed } = log().ns('test').error('This is an error!');
+  const { printed: w_printed } = log().warn('This is a warn!');
+  const { printed: i_printed } = log().ns('test').info('This is an info!');
+  const { printed: f_printed } = log().fail('This is a failure!');
+  const { printed: s_printed } = log().success('This is a success!');
+  const { printed: l_printed } = log()
     .ns(['test', 'test2'])
     .log('This is a log!');
-  const { render: d_render } = log().ns('test2').debug('This is a debug!');
-  const { render: v_render } = log().verbose('This is a verbose!');
+  const { printed: d_printed } = log().ns('test2').debug('This is a debug!');
+  const { printed: v_printed } = log().verbose('This is a verbose!');
 
-  t.falsy(a_render);
-  t.truthy(e_render);
-  t.falsy(w_render);
-  t.truthy(i_render);
-  t.falsy(f_render);
-  t.falsy(s_render);
-  t.truthy(l_render);
-  t.falsy(d_render);
-  t.falsy(v_render);
+  t.falsy(a_printed);
+  t.truthy(e_printed);
+  t.falsy(w_printed);
+  t.truthy(i_printed);
+  t.falsy(f_printed);
+  t.falsy(s_printed);
+  t.truthy(l_printed);
+  t.falsy(d_printed);
+  t.falsy(v_printed);
 });

--- a/test/browser/customize.ts
+++ b/test/browser/customize.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, defaults } from '../../src';
+import adze, { defaults } from '../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/defaults-emoji.ts
+++ b/test/browser/defaults-emoji.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, defaults } from '../../src';
+import adze, { defaults } from '../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/defaults.ts
+++ b/test/browser/defaults.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, defaults } from '../../src';
+import adze, { defaults } from '../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/conditional.ts
+++ b/test/browser/modifiers/conditional.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, defaults } from '../../../src';
+import adze, { defaults } from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/counting.ts
+++ b/test/browser/modifiers/counting.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/grouping.ts
+++ b/test/browser/modifiers/grouping.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, defaults } from '../../../src';
+import adze, { defaults } from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/identifying.ts
+++ b/test/browser/modifiers/identifying.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze } from '../../../src';
+import adze from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/mdc.ts
+++ b/test/browser/modifiers/mdc.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/browser/modifiers/timing.ts
+++ b/test/browser/modifiers/timing.ts
@@ -2,7 +2,7 @@
 const browserEnv = require('browser-env');
 import test from 'ava';
 import { formatISO } from 'date-fns';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 // Simulate the browser environment for testing
 browserEnv();

--- a/test/bundle.ts
+++ b/test/bundle.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, bundle, createShed, removeShed } from '../src';
+import adze, { bundle, createShed, removeShed } from '../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -1,6 +1,5 @@
 import test from 'ava';
-import {
-  adze,
+import adze, {
   bundle,
   filterNamespace,
   filterLabel,

--- a/test/formatting.ts
+++ b/test/formatting.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze } from '../src';
+import adze from '../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/grouping.ts
+++ b/test/grouping.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze } from '../src';
+import adze from '../src';
 
 // Our global context is the window not global
 global.ADZE_ENV = 'dev';

--- a/test/identifying.ts
+++ b/test/identifying.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, createShed, removeShed } from '../src';
+import adze, { createShed, removeShed } from '../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/mdc.ts
+++ b/test/mdc.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, createShed, removeShed } from '../src';
+import adze, { createShed, removeShed } from '../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/meta.ts
+++ b/test/meta.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze } from '../src';
+import adze from '../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/node/customize.ts
+++ b/test/node/customize.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, ChalkStyle } from '../../src';
+import adze, { ChalkStyle } from '../../src';
 import { applyChalkStyles } from '../../src/util';
 
 global.ADZE_ENV = 'dev';

--- a/test/node/defaults-emoji.ts
+++ b/test/node/defaults-emoji.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, defaults } from '../../src';
+import adze, { defaults } from '../../src';
 import { applyChalkStyles } from '../../src/util';
 
 global.ADZE_ENV = 'dev';

--- a/test/node/defaults.ts
+++ b/test/node/defaults.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, ChalkStyle, defaults } from '../../src';
+import adze, { ChalkStyle, defaults } from '../../src';
 import { applyChalkStyles } from '../../src/util';
 
 global.ADZE_ENV = 'dev';

--- a/test/node/modifiers/conditional.ts
+++ b/test/node/modifiers/conditional.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, defaults } from '../../../src';
+import adze, { defaults } from '../../../src';
 import { applyChalkStyles } from '../../../src/util';
 
 global.ADZE_ENV = 'dev';

--- a/test/node/modifiers/counting.ts
+++ b/test/node/modifiers/counting.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/node/modifiers/grouping.ts
+++ b/test/node/modifiers/grouping.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, defaults } from '../../../src';
+import adze, { defaults } from '../../../src';
 import { applyChalkStyles } from '../../../src/util';
 
 global.ADZE_ENV = 'dev';

--- a/test/node/modifiers/identifying.ts
+++ b/test/node/modifiers/identifying.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze } from '../../../src';
+import adze from '../../../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/node/modifiers/mdc.ts
+++ b/test/node/modifiers/mdc.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/node/modifiers/timing.ts
+++ b/test/node/modifiers/timing.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import { formatISO } from 'date-fns';
-import { adze, createShed, removeShed } from '../../../src';
+import adze, { createShed, removeShed } from '../../../src';
 
 global.ADZE_ENV = 'dev';
 

--- a/test/seal.ts
+++ b/test/seal.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { adze, createShed, removeShed } from '../src';
+import adze, { createShed, removeShed } from '../src';
 
 // Our global context is the window not global
 global.ADZE_ENV = 'dev';

--- a/test/shed.ts
+++ b/test/shed.ts
@@ -1,8 +1,7 @@
 import anyTest, { TestInterface } from 'ava';
 import { Shed } from '../src/shed/Shed';
-import {
+import adze, {
   createShed,
-  adze,
   removeShed,
   shedExists,
   isFinalLogData,
@@ -189,7 +188,7 @@ test('removes a log listener', (t) => {
 });
 
 test('fires the log listeners', (t) => {
-  const { log, render } = adze().info('A basic log.');
+  const { log, render, printed } = adze().info('A basic log.');
 
   const shed = createShed();
   shed.addListener([3], () => {
@@ -198,7 +197,7 @@ test('fires the log listeners', (t) => {
 
   const data = log.data;
   if (isFinalLogData(data)) {
-    shed.fireListeners(data, render);
+    shed.fireListeners(data, render, printed);
   } else {
     t.fail();
   }


### PR DESCRIPTION
- Logs will always render and store their render. To know if a log was printed to the console
terminated logs now expose the "printed" boolean that indicates if it was printed.
- Log listeners now receive the printed boolean. Rather than checking for render equal to null, listeners
should now check the printed boolean.
- `adze` is now also exported as default. You can import it by default or by named import.