### PR TITLE
fix(timestamp): timestamp incorrectly formatted

### DIFF
--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -21,28 +21,29 @@ export function timestamp(): LogTimestamp {
 export function iso8601Timestamp(milli: number): string {
   const d = new Date(milli);
 
-  const year = d.getUTCFullYear();
-  const month = twoDigitWholeNumber(d.getUTCMonth() + 1);
-  const day = twoDigitWholeNumber(d.getUTCDate());
-  // console.log('====', d.getTimezoneOffset(), d.getTimezoneOffset() / 60);
-  const hours = twoDigitWholeNumber(
-    d.getUTCHours() - d.getTimezoneOffset() / 60
-  );
-  const minutes = twoDigitWholeNumber(d.getUTCMinutes());
-  const seconds = twoDigitWholeNumber(d.getUTCSeconds());
+  const year = d.getFullYear();
+  const month = leadingZeros(2, d.getMonth() + 1);
+  const day = leadingZeros(2, d.getDate());
+  const hours = leadingZeros(2, d.getHours());
+  const minutes = leadingZeros(2, d.getMinutes());
+  const seconds = leadingZeros(2, d.getSeconds());
   const timezone = formatTimezoneOffset(d.getTimezoneOffset());
+  const milliseconds = leadingZeros(3, d.getMilliseconds());
 
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${timezone}`;
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}${timezone}`;
 }
 
 /**
- * Converts a number to a two digit positive whole number string.
+ * Adds leading zeros to a number to make it equal the provided digit count.
  *
- * Example: twoDigitWholeNumber(4) => '04'
+ * Example: leadingZeros(2, 4) => '04'
  */
-export function twoDigitWholeNumber(val: number): string {
-  const num = Math.abs(val);
-  return num < 10 ? `0${num}` : `${num}`;
+export function leadingZeros(digits: number, num: number): string {
+  let leadingZeros = '';
+  for (let i = 0; i < digits - `${num}`.length; i += 1) {
+    leadingZeros += '0';
+  }
+  return `${leadingZeros}${num}`;
 }
 
 /**
@@ -54,10 +55,8 @@ export function formatTimezoneOffset(raw: number): string {
     return 'Z';
   }
 
-  const isNegative = raw < 0;
-  return `${isNegative ? '+' : '-'}${
-    offset > 9 ? `${offset}` : `0${offset}`
-  }:00`;
+  const sign = raw < 0 ? '+' : '-';
+  return `${sign}${leadingZeros(2, offset)}:00`;
 }
 
 /**

--- a/test/browser/modifiers/timing.ts
+++ b/test/browser/modifiers/timing.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const browserEnv = require('browser-env');
 import test from 'ava';
-import { formatISO } from 'date-fns';
+import { format } from 'date-fns';
 import adze, { createShed, removeShed } from '../../../src';
 
 // Simulate the browser environment for testing
@@ -52,12 +52,15 @@ test('renders iso8601 timestamp properly', (t) => {
   if (args && milli && typeof args[2] === 'string') {
     // Get a date object to generate a timestamp with date-fns to check for accuracy
     const compareDate = new Date(milli);
+    const ymd = format(compareDate, 'yyyy-MM-dd');
+    const hmsSx = format(compareDate, 'HH:mm:ss.SSSxxx');
+    const compareDateStr = `${ymd}T${hmsSx}  `;
 
     t.regex(
       args[2],
-      /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])([+-][0-9]{2}:[0-9]+)?(Z)?\s\s$/g
+      /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]).[0-9]{3}([+-][0-9]{2}:[0-9]+)?(Z)?\s+$/g
     );
-    t.is(args[2], `${formatISO(compareDate)}  `);
+    t.is(args[2], compareDateStr);
   } else {
     t.fail();
   }

--- a/test/node/modifiers/timing.ts
+++ b/test/node/modifiers/timing.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { formatISO } from 'date-fns';
+import { format } from 'date-fns';
 import adze, { createShed, removeShed } from '../../../src';
 
 global.ADZE_ENV = 'dev';
@@ -47,12 +47,16 @@ test('renders iso8601 timestamp properly', (t) => {
   if (args && milli && typeof args[1] === 'string') {
     // Get a date object to generate a timestamp with date-fns to check for accuracy
     const compareDate = new Date(milli);
+    const ymd = format(compareDate, 'yyyy-MM-dd');
+    const hmsSx = format(compareDate, 'HH:mm:ss.SSSxxx');
+    const compareDateStr = `${ymd}T${hmsSx}  `;
 
     t.regex(
       args[1],
-      /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])([+-][0-9]{2}:[0-9]+)?(Z)?\s\s$/g
+      /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]).[0-9]{3}([+-][0-9]{2}:[0-9]+)?(Z)?\s+$/g
     );
-    t.is(args[1], `${formatISO(compareDate)}  `);
+
+    t.is(args[1], compareDateStr);
   } else {
     t.fail();
   }

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import { leadingZeros } from '../src/util';
+
+global.ADZE_ENV = 'dev';
+
+test('properly pads a number with leading zeros', (t) => {
+  const result = leadingZeros(5, 65);
+  const lessThan = leadingZeros(1, 65);
+
+  t.is(result, '00065');
+  t.is(lessThan, '65');
+});


### PR DESCRIPTION
Fixes bug where timestamp was incorrectly printing UTC time rather than local time.