### PR TITLE
Add support for namespace modifier to allow rest parameters

### DIFF
--- a/demo_funcs.js
+++ b/demo_funcs.js
@@ -319,6 +319,8 @@ function withNamespace({ adze }) {
 function withMultiNamespace({ adze }) {
   console.log('\n----- Default Multiple Namespace Log w/ No Store -----\n');
   adze().ns(['foo', 'bar']).info('This log has multiple namespaces.');
+  adze().namespace('foo', 'bar', 'baz').info('Testing multiple namespaces using rest parameters.');
+  adze().ns('foo', 'bar', 'baz').info('Testing multiple namespaces using rest parameters with the ns() alias.');
 }
 
 function withTime({ adze }) {

--- a/src/log/BaseLog.ts
+++ b/src/log/BaseLog.ts
@@ -586,9 +586,11 @@ export class BaseLog {
    *
    * This is a non-standard API.
    */
-  public namespace(ns: string | string[]): this {
+  public namespace(ns: string[]): this;
+  public namespace(...rest: string[]): this;
+  public namespace(ns: string | string[], ...rest: string[]): this {
     return this.modifier((ctxt) => {
-      ctxt._namespaceVal = isString(ns) ? [ns] : ns;
+      ctxt._namespaceVal = isString(ns) ? [ns, ...rest] : ns;
     });
   }
 
@@ -597,8 +599,10 @@ export class BaseLog {
    *
    * This is a non-standard API.
    */
-  public ns(ns: string | string[]): this {
-    return this.namespace(ns);
+  public ns(ns: string[]): this;
+  public ns(...rest: string[]): this;
+  public ns(ns: string | string[], ...rest: string[]): this {
+    return this.namespace(ns as string, ...rest);
   }
 
   /**

--- a/test/browser/modifiers/identifying.ts
+++ b/test/browser/modifiers/identifying.ts
@@ -37,3 +37,13 @@ test('log with multiple namespaces prints correctly', (t) => {
     t.fail();
   }
 });
+
+test('log with multiple namespaces using rest parameters prints correctly', (t) => {
+  const { render } = adze().ns('test', 'test2').log('This log has a label.');
+  if (render) {
+    const [_, args] = render;
+    t.is(args[2], '#test #test2 ');
+  } else {
+    t.fail();
+  }
+});

--- a/test/node/modifiers/identifying.ts
+++ b/test/node/modifiers/identifying.ts
@@ -32,3 +32,13 @@ test('log with multiple namespaces prints correctly', (t) => {
     t.fail();
   }
 });
+
+test('log with multiple namespaces using rest parameters prints correctly', (t) => {
+  const { render } = adze().ns('test', 'test2').log('This log has a label.');
+  if (render) {
+    const [_, args] = render;
+    t.is(args[1], '#test #test2 ');
+  } else {
+    t.fail();
+  }
+});


### PR DESCRIPTION
re: #105 
I had to modify a bit the previously proposed signature for the `namespace` overloads. The previous was satisfying the calls but the body method wasn't receiving the rest arguments.

I also added some unit tests and a couple of log demos on `demo_funcs.js`

Let me know how it looks and if something needs to be modified.