### PR TITLE
feat(namespace): multiple calls to namespace modifier are additive

### DIFF
--- a/demo_funcs.js
+++ b/demo_funcs.js
@@ -274,6 +274,7 @@ function bundleLogs({
   log().ns(['foo', 'SPACE']).info('A bundled log with multiple namespaces.');
   log().label('i-am-label').success('Successfully bundled this log!');
   log().log('Here is another log in the bundle.');
+  log().ns('foo', 'bar').ns('baz').log('Multiple calls to namespace are additive.');
 
   divider.info('---- Next is a recall of all logs in the bundle ----');
   log().bundle.forEach(rerender);

--- a/src/log/BaseLog.ts
+++ b/src/log/BaseLog.ts
@@ -583,7 +583,8 @@ export class BaseLog<C extends Constraints> {
 
   /**
    * Adds a namespace to the log. Namespace's are primarily useful
-   * for grouping logs together.
+   * for grouping logs together. Multiple calls to namespace are
+   * additive in nature.
    *
    * This is a non-standard API.
    */
@@ -594,7 +595,8 @@ export class BaseLog<C extends Constraints> {
     ...rest: C['allowedNamespaces'][]
   ): this {
     return this.modifier((ctxt) => {
-      ctxt._namespaceVal = isString(ns) ? [ns, ...rest] : ns;
+      const namespace = isString(ns) ? [ns, ...rest] : ns;
+      ctxt._namespaceVal = [...(ctxt._namespaceVal ?? []), ...namespace];
     });
   }
 

--- a/test/browser/modifiers/identifying.ts
+++ b/test/browser/modifiers/identifying.ts
@@ -47,3 +47,16 @@ test('log with multiple namespaces using rest parameters prints correctly', (t) 
     t.fail();
   }
 });
+
+test('multiple calls to namespace are additive', (t) => {
+  const { render } = adze()
+    .ns('foo', 'bar')
+    .ns('baz')
+    .log('This log has multiple namespaces that are added together.');
+  if (render) {
+    const [_, args] = render;
+    t.is(args[2], '#foo #bar #baz ');
+  } else {
+    t.fail();
+  }
+});

--- a/test/node/modifiers/identifying.ts
+++ b/test/node/modifiers/identifying.ts
@@ -14,7 +14,7 @@ test('label prints correctly', (t) => {
 });
 
 test('log with single namespace prints correctly', (t) => {
-  const { render } = adze().ns('test').log('This log has a label.');
+  const { render } = adze().ns('test').log('This log has a namespace.');
   if (render) {
     const [_, args] = render;
     t.is(args[1], '#test ');
@@ -24,7 +24,7 @@ test('log with single namespace prints correctly', (t) => {
 });
 
 test('log with multiple namespaces prints correctly', (t) => {
-  const { render } = adze().ns(['test', 'test2']).log('This log has a label.');
+  const { render } = adze().ns(['test', 'test2']).log('This log has two namespaces.');
   if (render) {
     const [_, args] = render;
     t.is(args[1], '#test #test2 ');
@@ -34,10 +34,25 @@ test('log with multiple namespaces prints correctly', (t) => {
 });
 
 test('log with multiple namespaces using rest parameters prints correctly', (t) => {
-  const { render } = adze().ns('test', 'test2').log('This log has a label.');
+  const { render } = adze()
+    .ns('test', 'test2')
+    .log('This log has multiple namespaces using restof operator.');
   if (render) {
     const [_, args] = render;
     t.is(args[1], '#test #test2 ');
+  } else {
+    t.fail();
+  }
+});
+
+test('multiple calls to namespace are additive', (t) => {
+  const { render } = adze()
+    .ns('foo', 'bar')
+    .ns('baz')
+    .log('This log has multiple namespaces that are added together.');
+  if (render) {
+    const [_, args] = render;
+    t.is(args[1], '#foo #bar #baz ');
   } else {
     t.fail();
   }


### PR DESCRIPTION
If you call namespace on a log that already contains a set of namespaces it will add the new
namespace to the set rather than overwriting it.

fix #120