### PR TITLE
fix: silent now correctly returns a render and printed is false

### DIFF
--- a/demo_funcs.js
+++ b/demo_funcs.js
@@ -11,6 +11,7 @@ export default function runDemo(lib, el) {
   logLevelOf2(lib);
   bundleLogs(lib);
   sealLogModifiers(lib);
+  withSilent(lib);
   withLabel(lib);
   withNamespace(lib);
   withMultiNamespace(lib);
@@ -289,6 +290,18 @@ function sealLogModifiers({ adze }) {
 
   sealed().success('Successfully sealed this log!');
   sealed().log('Here is another sealed log.');
+}
+
+function withSilent({ adze, createShed, removeShed }) {
+  console.log('\n----- Silent Log -----\n');
+  const shed = createShed();
+  shed.addListener([6], (data, render, printed) => {
+    adze().test(data.isSilent === true).success('The log is silent!', data);
+    adze().test(render !== null).success('Render is not null!', render);
+    adze().test(printed === false).success('The log did not print!', printed);
+  });
+  adze().silent.log('Testing a silent log.');
+  removeShed();
 }
 
 function withLabel({ adze }) {

--- a/src/conditions/conditions.ts
+++ b/src/conditions/conditions.ts
@@ -8,7 +8,10 @@ import { getSearchParams } from '../util';
  */
 export function allowed(data: FinalLogData<any>): boolean {
   return (
-    levelActive(data.definition, data.cfg.logLevel) && notTestEnv() && passesFilters(data.cfg, data)
+    levelActive(data.definition, data.cfg.logLevel) &&
+    notTestEnv() &&
+    passesFilters(data.cfg, data) &&
+    notSilent(data)
   );
 }
 
@@ -40,4 +43,8 @@ export function notTestEnv(): boolean {
   const adze_env = Env.global()?.ADZE_ENV;
   const param = getSearchParams()?.get('ADZE_ENV');
   return (adze_env ?? param ?? '') !== 'test';
+}
+
+export function notSilent(data: FinalLogData<any>): boolean {
+  return data.isSilent === false;
 }

--- a/src/printers/Printer.ts
+++ b/src/printers/Printer.ts
@@ -45,35 +45,35 @@ export class Printer {
   // ------- PRINT METHODS -------- //
 
   public printLog(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printLog()));
+    return this.attachContext(this.printer.printLog());
   }
 
   public printGroup(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printGroup()));
+    return this.attachContext(this.printer.printGroup());
   }
 
   public printGroupCollapsed(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printGroupCollapsed()));
+    return this.attachContext(this.printer.printGroupCollapsed());
   }
 
   public printTrace(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printTrace()));
+    return this.attachContext(this.printer.printTrace());
   }
 
   public printGroupEnd(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printGroupEnd()));
+    return this.attachContext(this.printer.printGroupEnd());
   }
 
   public printTable(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printTable()));
+    return this.attachContext(this.printer.printTable());
   }
 
   public printDir(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printDir()));
+    return this.attachContext(this.printer.printDir());
   }
 
   public printDirxml(): LogRender | null {
-    return this.checkSilent(this.attachContext(this.printer.printDirxml()));
+    return this.attachContext(this.printer.printDirxml());
   }
 
   // =======================
@@ -87,16 +87,6 @@ export class Printer {
   private attachContext(render: LogRender | null): LogRender | null {
     if (render && this.data.dumpContext && !this.data.cfg.machineReadable) {
       return [render[0], [...render[1], this.data.context]];
-    }
-    return render;
-  }
-
-  /**
-   * If the log data is flagged as silent, return null instead of the log render.
-   */
-  private checkSilent(render: LogRender | null): LogRender | null {
-    if (this.data.isSilent) {
-      return null;
     }
     return render;
   }

--- a/test/formatting.ts
+++ b/test/formatting.ts
@@ -41,12 +41,3 @@ test('table log terminates properly.', (t) => {
     t.fail();
   }
 });
-
-test('silent modifier prevents log rendering', (t) => {
-  const { render } = adze().silent.alert('This log should not render.');
-  if (render) {
-    t.fail();
-  } else {
-    t.pass();
-  }
-});

--- a/test/shed.ts
+++ b/test/shed.ts
@@ -265,3 +265,15 @@ test('shed tools renderLabel renders appropriate logs with provided level and la
   t.is(renderedAll.length, 4);
   t.is(renderedWarn.length, 1);
 });
+
+test('log listeners should have printed set to false when a log is silent', (t) => {
+  const shed = createShed();
+
+  shed.addListener([0], (data, render, printed) => {
+    t.true(data.isSilent);
+    t.not(render, null);
+    t.false(printed);
+  });
+
+  adze().silent.alert('This log is silent.');
+});


### PR DESCRIPTION
The silent modifier now correctly returns a render tuple and the printed value in log listeners will
be false.

fix #126