### PR TITLE
feat: refactors namespace to always use restof parameters rather than arrays

### DIFF
--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -12,7 +12,6 @@ import {
   TerminatedLog,
 } from '../_contracts';
 import {
-  isString,
   stacktrace,
   timestamp,
   toConsole,
@@ -607,15 +606,9 @@ export class Log<C extends Constraints> {
    *
    * This is a non-standard API.
    */
-  public namespace(ns: C['allowedNamespaces'][]): this;
-  public namespace(...rest: C['allowedNamespaces'][]): this;
-  public namespace(
-    ns: C['allowedNamespaces'] | C['allowedNamespaces'][],
-    ...rest: C['allowedNamespaces'][]
-  ): this {
+  public namespace(...namespaces: C['allowedNamespaces'][]): this {
     return this.modifier((ctxt) => {
-      const namespace = isString(ns) ? [ns, ...rest] : ns;
-      ctxt._namespaceVal = [...(ctxt._namespaceVal ?? []), ...namespace];
+      ctxt._namespaceVal = [...(ctxt._namespaceVal ?? []), ...namespaces];
     });
   }
 
@@ -624,13 +617,8 @@ export class Log<C extends Constraints> {
    *
    * This is a non-standard API.
    */
-  public ns(ns: C['allowedNamespaces'][]): this;
-  public ns(...rest: C['allowedNamespaces'][]): this;
-  public ns(
-    ns: C['allowedNamespaces'] | C['allowedNamespaces'][],
-    ...rest: C['allowedNamespaces'][]
-  ): this {
-    return this.namespace(ns as string, ...rest);
+  public ns(...namespaces: C['allowedNamespaces'][]): this {
+    return this.namespace(...namespaces);
   }
 
   /**

--- a/test/adze.ts
+++ b/test/adze.ts
@@ -188,7 +188,7 @@ test('global filter excludes logs based on namespace', (t) => {
   const { printed: i_printed } = log().ns('testWOW').info('This is an info!');
   const { printed: f_printed } = log().fail('This is a failure!');
   const { printed: s_printed } = log().success('This is a success!');
-  const { printed: l_printed } = log().ns(['testWOW', 'test2']).log('This is a log!');
+  const { printed: l_printed } = log().ns('testWOW', 'test2').log('This is a log!');
   const { printed: d_printed } = log().ns('test2').debug('This is a debug!');
   const { printed: v_printed } = log().verbose('This is a verbose!');
 
@@ -220,7 +220,7 @@ test('global filter includes logs based on namespace', (t) => {
   const { printed: i_printed } = log().ns('test').info('This is an info!');
   const { printed: f_printed } = log().fail('This is a failure!');
   const { printed: s_printed } = log().success('This is a success!');
-  const { printed: l_printed } = log().ns(['test', 'test2']).log('This is a log!');
+  const { printed: l_printed } = log().ns('test', 'test2').log('This is a log!');
   const { printed: d_printed } = log().ns('test2').debug('This is a debug!');
   const { printed: v_printed } = log().verbose('This is a verbose!');
 

--- a/test/browser/modifiers/identifying.ts
+++ b/test/browser/modifiers/identifying.ts
@@ -29,16 +29,6 @@ test('log with single namespace prints correctly', (t) => {
 });
 
 test('log with multiple namespaces prints correctly', (t) => {
-  const { render } = adze().ns(['test', 'test2']).log('This log has a label.');
-  if (render) {
-    const [_, args] = render;
-    t.is(args[2], '#test #test2 ');
-  } else {
-    t.fail();
-  }
-});
-
-test('log with multiple namespaces using rest parameters prints correctly', (t) => {
   const { render } = adze().ns('test', 'test2').log('This log has a label.');
   if (render) {
     const [_, args] = render;

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -18,7 +18,7 @@ test.serial('filters a log collection by namespace', (t) => {
   const shed = createShed();
 
   adze().ns('SPACE').error('This is an error!');
-  adze().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
+  adze().ns('foo', 'SPACE').info('A bundled log with namespaces.');
   adze().label('i-am-label').success('Successfully bundled this log!');
   adze().log('Here is another log in the bundle.');
 
@@ -34,7 +34,7 @@ test.serial('filters a log collection by label', (t) => {
   const shed = createShed();
 
   adze().ns('SPACE').error('This is an error!');
-  adze().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
+  adze().ns('foo', 'SPACE').info('A bundled log with namespaces.');
   adze().label('i-am-label').success('Successfully bundled this log!');
   adze().log('Here is another log in the bundle.');
 
@@ -50,7 +50,7 @@ test.serial('filters a log collection by levels', (t) => {
   const shed = createShed();
 
   adze().ns('SPACE').error('This is an error!');
-  adze().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
+  adze().ns('foo', 'SPACE').info('A bundled log with namespaces.');
   adze().label('i-am-label').success('Successfully bundled this log!');
   adze().log('Here is another log in the bundle.');
 
@@ -66,7 +66,7 @@ test.serial('filterCollection filters collection by a log data value', (t) => {
   const shed = createShed();
 
   adze().ns('SPACE').silent.error('This is an error!');
-  adze().ns(['foo', 'SPACE']).info('A bundled log with namespaces.');
+  adze().ns('foo', 'SPACE').info('A bundled log with namespaces.');
   adze().label('i-am-label').success('Successfully bundled this log!');
   adze().log('Here is another log in the bundle.');
 

--- a/test/machine/modifiers/identifying.ts
+++ b/test/machine/modifiers/identifying.ts
@@ -56,35 +56,6 @@ test('log with single namespace prints correctly', (t) => {
 
 test('log with multiple namespaces prints correctly', (t) => {
   const { log, render } = adze({ machineReadable: true })
-    .ns(['test', 'test2'])
-    .log('This log has multiple namespaces.');
-
-  t.truthy(log);
-  if (render) {
-    const [method, args] = render;
-    t.is(method, 'log');
-    t.is(args.length, 1);
-
-    const parsed: JsonOutput = JSON.parse(args[0] as string);
-    t.is(parsed.method, 'log');
-    t.is(parsed.level, 6);
-    t.is(parsed.levelName, 'log');
-    if (parsed.namespace) {
-      t.is(parsed.namespace.length, 2);
-      t.is(parsed.namespace[0], 'test');
-      t.is(parsed.namespace[1], 'test2');
-    } else {
-      t.fail();
-    }
-    t.is(parsed.args.length, 1);
-    t.is(parsed.args[0], 'This log has multiple namespaces.');
-  } else {
-    t.fail();
-  }
-});
-
-test('log with multiple namespaces using rest parameters prints correctly', (t) => {
-  const { log, render } = adze({ machineReadable: true })
     .ns('test', 'test2')
     .log('This log has multiple namespaces.');
 

--- a/test/node/modifiers/identifying.ts
+++ b/test/node/modifiers/identifying.ts
@@ -24,19 +24,7 @@ test('log with single namespace prints correctly', (t) => {
 });
 
 test('log with multiple namespaces prints correctly', (t) => {
-  const { render } = adze().ns(['test', 'test2']).log('This log has two namespaces.');
-  if (render) {
-    const [_, args] = render;
-    t.is(args[1], '#test #test2 ');
-  } else {
-    t.fail();
-  }
-});
-
-test('log with multiple namespaces using rest parameters prints correctly', (t) => {
-  const { render } = adze()
-    .ns('test', 'test2')
-    .log('This log has multiple namespaces using restof operator.');
+  const { render } = adze().ns('test', 'test2').log('This log has two namespaces.');
   if (render) {
     const [_, args] = render;
     t.is(args[1], '#test #test2 ');

--- a/test/seal.ts
+++ b/test/seal.ts
@@ -5,7 +5,7 @@ import adze, { createShed, removeShed } from '../src';
 global.ADZE_ENV = 'dev';
 
 test('sealing a log preserves configuration but creates new log instances', (t) => {
-  const sealed = adze().label('test').ns(['test1', 'test2']).seal();
+  const sealed = adze().label('test').ns('test1', 'test2').seal();
   const { log: log1, render: render1 } = sealed().log('Log #1');
   const { log: log2, render: render2 } = sealed().info('Log #2');
 


### PR DESCRIPTION
Refactors the namespace and ns modifiers to only accept strings as restof parameters rather than arrays of strings.

BREAKING CHANGE: The namespace and ns modifiers can no longer accept string arrays and must use comma separated string parameters.

close #148